### PR TITLE
Use shared navy and gold color variables

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,71 +1,116 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About – Ulix</title>
-  <meta name="description" content="Ulix LLC creates precision, privacy-first tools for modern odysseys. Learn about our mission, values, and the people behind our apps." />
-  <link rel="icon" href="/favicon.png" />
-  <meta property="og:title" content="About – Ulix" />
-  <meta property="og:description" content="Ulix LLC creates precision, privacy-first tools for modern odysseys." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://ulix.app/about.html" />
-  <meta property="og:image" content="https://ulix.app/favicon.png" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="About – Ulix" />
-  <meta name="twitter:description" content="Ulix LLC creates precision, privacy-first tools for modern odysseys." />
-  <meta name="twitter:image" content="https://ulix.app/favicon.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <style>
-    :root { --ulix-bg: #0b0d12; --ulix-ink: #eaeef7; --ulix-accent: #5eead4; }
-    .ulix-bg { background: var(--ulix-bg); }
-    .ulix-ink { color: var(--ulix-ink); }
-    .ulix-muted { color: #b7c0d1; }
-    .ulix-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
-    .glow { box-shadow: 0 8px 30px rgba(94,234,212,0.25); }
-  </style>
-</head>
-<body class="ulix-bg ulix-ink antialiased">
-  <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
-    <a href="/" class="flex items-center gap-3 group">
-      <img src="/favicon.png" alt="Ulix" class="w-8 h-8" />
-      <span class="font-semibold tracking-tight group-hover:opacity-90">Ulix</span>
-    </a>
-    <nav class="hidden md:flex items-center gap-6 text-sm">
-      <a href="/" class="hover:opacity-90">Apps</a>
-      <a href="/about.html" class="hover:opacity-90 font-semibold">About</a>
-    </nav>
-  </header>
-
-  <section class="max-w-4xl mx-auto px-4 py-10 md:py-16">
-    <h1 class="text-3xl md:text-5xl font-semibold leading-tight">About Ulix</h1>
-    <p class="ulix-muted mt-4 text-lg">Ulix LLC builds precision, privacy-first tools for modern odysseys—apps and software that put users in control of their data, simplify everyday tasks, and enhance creativity. We believe technology should serve people, not harvest them.</p>
-
-    <div class="mt-10 grid md:grid-cols-2 gap-8">
-      <div class="ulix-card rounded-2xl p-6">
-        <h2 class="text-xl font-semibold mb-2">Our Mission</h2>
-        <p class="ulix-muted">We design tools that are fast, focused, and respectful of your privacy. From scanning bookshelves offline to tracking health without accounts, every Ulix product is built to be both powerful and private.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <h2 class="text-xl font-semibold mb-2">Our Values</h2>
-        <ul class="list-disc list-inside ulix-muted">
-          <li>Privacy-first design</li>
-          <li>Local-first processing</li>
-          <li>Elegant simplicity</li>
-          <li>User autonomy</li>
-        </ul>
-      </div>
-    </div>
-
-    <div class="mt-10">
-      <a href="/" class="inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/15 transition glow">
-        <span class="font-medium">Explore our apps</span>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About – Ulix</title>
+    <meta
+      name="description"
+      content="Ulix LLC creates precision, privacy-first tools for modern odysseys. Learn about our mission, values, and the people behind our apps."
+    />
+    <link rel="icon" href="/favicon.png" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+    <meta property="og:title" content="About – Ulix" />
+    <meta
+      property="og:description"
+      content="Ulix LLC creates precision, privacy-first tools for modern odysseys."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://ulix.app/about.html" />
+    <meta property="og:image" content="https://ulix.app/favicon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="About – Ulix" />
+    <meta
+      name="twitter:description"
+      content="Ulix LLC creates precision, privacy-first tools for modern odysseys."
+    />
+    <meta name="twitter:image" content="https://ulix.app/favicon.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      :root {
+        --ulix-bg: #0b0d12;
+        --ulix-ink: #eaeef7;
+      }
+      .ulix-bg {
+        background: var(--ulix-bg);
+      }
+      .ulix-ink {
+        color: var(--ulix-ink);
+      }
+      .ulix-muted {
+        color: #b7c0d1;
+      }
+      .ulix-card {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+      .glow {
+        box-shadow: 0 8px 30px color-mix(in srgb, var(--gold), transparent 75%);
+      }
+    </style>
+  </head>
+  <body class="ulix-bg ulix-ink antialiased">
+    <header
+      class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between"
+    >
+      <a href="/" class="flex items-center gap-3 group">
+        <img src="/favicon.png" alt="Ulix" class="w-8 h-8" />
+        <span class="font-semibold tracking-tight group-hover:opacity-90"
+          >Ulix</span
+        >
       </a>
-    </div>
-  </section>
+      <nav class="hidden md:flex items-center gap-6 text-sm">
+        <a href="/" class="hover:opacity-90">Apps</a>
+        <a href="/about.html" class="hover:opacity-90 font-semibold">About</a>
+      </nav>
+    </header>
 
-  <footer class="max-w-6xl mx-auto px-4 py-10">
-    <div class="text-sm ulix-muted">© 2025 Ulix. Precision Tools for Modern Odysseys.</div>
-  </footer>
-</body>
+    <section class="max-w-4xl mx-auto px-4 py-10 md:py-16">
+      <h1 class="text-3xl md:text-5xl font-semibold leading-tight">
+        About Ulix
+      </h1>
+      <p class="ulix-muted mt-4 text-lg">
+        Ulix LLC builds precision, privacy-first tools for modern odysseys—apps
+        and software that put users in control of their data, simplify everyday
+        tasks, and enhance creativity. We believe technology should serve
+        people, not harvest them.
+      </p>
+
+      <div class="mt-10 grid md:grid-cols-2 gap-8">
+        <div class="ulix-card rounded-2xl p-6">
+          <h2 class="text-xl font-semibold mb-2">Our Mission</h2>
+          <p class="ulix-muted">
+            We design tools that are fast, focused, and respectful of your
+            privacy. From scanning bookshelves offline to tracking health
+            without accounts, every Ulix product is built to be both powerful
+            and private.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <h2 class="text-xl font-semibold mb-2">Our Values</h2>
+          <ul class="list-disc list-inside ulix-muted">
+            <li>Privacy-first design</li>
+            <li>Local-first processing</li>
+            <li>Elegant simplicity</li>
+            <li>User autonomy</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mt-10">
+        <a
+          href="/"
+          class="inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/15 transition glow"
+        >
+          <span class="font-medium">Explore our apps</span>
+        </a>
+      </div>
+    </section>
+
+    <footer class="max-w-6xl mx-auto px-4 py-10">
+      <div class="text-sm ulix-muted">
+        © 2025 Ulix. Precision Tools for Modern Odysseys.
+      </div>
+    </footer>
+  </body>
 </html>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,4 @@
+:root {
+  --navy-blue: #1a2332;
+  --gold: #d4af37;
+}

--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -1,52 +1,82 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/assets/styles.css" />
     <title>Guten Privacy Policy</title>
     <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            margin: 0;
-            padding: 2rem;
-            line-height: 1.6;
-            background-color: #ffffff;
-            color: #1a1a1a;
-        }
-        main {
-            max-width: 720px;
-            margin: 0 auto;
-        }
-        h1 {
-            font-size: 2rem;
-            margin-bottom: 1rem;
-        }
-        p {
-            margin-bottom: 1rem;
-        }
-        footer {
-            margin-top: 3rem;
-            font-size: 0.9rem;
-            color: #888;
-            text-align: center;
-        }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.6;
+        background-color: #ffffff;
+        color: var(--navy-blue);
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+        color: var(--gold);
+      }
+      p {
+        margin-bottom: 1rem;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: var(--gold);
+        text-align: center;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <main>
-        <h1>Guten Privacy Policy</h1>
-        <p><strong>Guten</strong> is a reading app that helps you explore public-domain books with full respect for your privacy. Here's how your data is handled:</p>
-        <ul>
-            <li>The app uses internet access only to fetch and download public-domain books and metadata from trusted sources such as the Gutendex API and Project Gutenberg.</li>
-            <li><strong>No personal information is collected, transmitted, or shared.</strong></li>
-            <li>Guten includes <strong>no analytics, advertising, or account-based services</strong>.</li>
-            <li>Downloaded books, bookmarks, reading progress, and similar records are stored <strong>locally</strong> on your device using private storage. This data never leaves your device unless you manually back it up or share it.</li>
-            <li>When opening or sharing external links (e.g., to Project Gutenberg), you may be directed to third-party websites. Their privacy policies apply independently of this app.</li>
-        </ul>
-        <p>Guten is designed to give you a distraction-free reading experience with complete control over your data.</p>
+      <h1>Guten Privacy Policy</h1>
+      <p>
+        <strong>Guten</strong> is a reading app that helps you explore
+        public-domain books with full respect for your privacy. Here's how your
+        data is handled:
+      </p>
+      <ul>
+        <li>
+          The app uses internet access only to fetch and download public-domain
+          books and metadata from trusted sources such as the Gutendex API and
+          Project Gutenberg.
+        </li>
+        <li>
+          <strong
+            >No personal information is collected, transmitted, or
+            shared.</strong
+          >
+        </li>
+        <li>
+          Guten includes
+          <strong>no analytics, advertising, or account-based services</strong>.
+        </li>
+        <li>
+          Downloaded books, bookmarks, reading progress, and similar records are
+          stored <strong>locally</strong> on your device using private storage.
+          This data never leaves your device unless you manually back it up or
+          share it.
+        </li>
+        <li>
+          When opening or sharing external links (e.g., to Project Gutenberg),
+          you may be directed to third-party websites. Their privacy policies
+          apply independently of this app.
+        </li>
+      </ul>
+      <p>
+        Guten is designed to give you a distraction-free reading experience with
+        complete control over your data.
+      </p>
     </main>
-    <footer>
-        Last updated: August 5, 2025
-    </footer>
-</body>
+    <footer>Last updated: August 5, 2025</footer>
+  </body>
 </html>

--- a/keepclipprivacypolicy.html
+++ b/keepclipprivacypolicy.html
@@ -1,53 +1,83 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/assets/styles.css" />
     <title>Keep Clip Privacy Policy</title>
     <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            margin: 0;
-            padding: 2rem;
-            line-height: 1.6;
-            background-color: #ffffff;
-            color: #1a1a1a;
-        }
-        main {
-            max-width: 720px;
-            margin: 0 auto;
-        }
-        h1 {
-            font-size: 2rem;
-            margin-bottom: 1rem;
-        }
-        p {
-            margin-bottom: 1rem;
-        }
-        footer {
-            margin-top: 3rem;
-            font-size: 0.9rem;
-            color: #888;
-            text-align: center;
-        }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.6;
+        background-color: #ffffff;
+        color: var(--navy-blue);
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+        color: var(--gold);
+      }
+      p {
+        margin-bottom: 1rem;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: var(--gold);
+        text-align: center;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <main>
-        <h1>Keep Clip Privacy Policy</h1>
-        <p><strong>Keep Clip</strong> is a tool for collecting and organizing text snippets with full respect for your privacy. Here's how your data is handled:</p>
-        <ul>
-            <li>All clips, tags, and context you save are stored <strong>locally</strong> on your device in a private database.</li>
-            <li>The app does <strong>not</strong> collect personal data or send your clips to any server.</li>
-            <li>Keep Clip includes <strong>no advertising, analytics, or third-party tracking libraries</strong>.</li>
-            <li>The app requests internet access only to fetch metadata (like page titles) for links you choose to save.</li>
-            <li>Your data stays on your device unless you choose to <strong>share or export</strong> it.</li>
-            <li>Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
-        </ul>
-        <p>Keep Clip is designed to give you full control over your saved text, with minimal permissions and no external data sharing.</p>
+      <h1>Keep Clip Privacy Policy</h1>
+      <p>
+        <strong>Keep Clip</strong> is a tool for collecting and organizing text
+        snippets with full respect for your privacy. Here's how your data is
+        handled:
+      </p>
+      <ul>
+        <li>
+          All clips, tags, and context you save are stored
+          <strong>locally</strong> on your device in a private database.
+        </li>
+        <li>
+          The app does <strong>not</strong> collect personal data or send your
+          clips to any server.
+        </li>
+        <li>
+          Keep Clip includes
+          <strong
+            >no advertising, analytics, or third-party tracking
+            libraries</strong
+          >.
+        </li>
+        <li>
+          The app requests internet access only to fetch metadata (like page
+          titles) for links you choose to save.
+        </li>
+        <li>
+          Your data stays on your device unless you choose to
+          <strong>share or export</strong> it.
+        </li>
+        <li>
+          Android's built-in backup system may back up the local database to
+          your Google account, depending on your device settings.
+        </li>
+      </ul>
+      <p>
+        Keep Clip is designed to give you full control over your saved text,
+        with minimal permissions and no external data sharing.
+      </p>
     </main>
-    <footer>
-        Last updated: August 5, 2025
-    </footer>
-</body>
+    <footer>Last updated: August 5, 2025</footer>
+  </body>
 </html>

--- a/shelfscan/android.html
+++ b/shelfscan/android.html
@@ -1,287 +1,613 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Shelf Scan — Find anything on your shelves in seconds</title>
-  <meta name="description" content="Point your camera at your shelves and search like CTRL+F. No organizing required. Works offline. One-time $1.99. Privacy-first." />
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+    <title>Shelf Scan — Find anything on your shelves in seconds</title>
+    <meta
+      name="description"
+      content="Point your camera at your shelves and search like CTRL+F. No organizing required. Works offline. One-time $1.99. Privacy-first."
+    />
 
-  <!-- Open Graph -->
-  <meta property="og:title" content="Shelf Scan — Camera shelf search" />
-  <meta property="og:description" content="Find books, movies, and games instantly by pointing your camera at your shelves. No cataloging. Works offline. One-time $1.99." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://ulix.app/shelfscan" />
-  <meta property="og:image" content="/assets/shelfscan-og.jpg" />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Shelf Scan — Camera shelf search" />
+    <meta
+      property="og:description"
+      content="Find books, movies, and games instantly by pointing your camera at your shelves. No cataloging. Works offline. One-time $1.99."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://ulix.app/shelfscan" />
+    <meta property="og:image" content="/assets/shelfscan-og.jpg" />
 
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Shelf Scan — Camera shelf search" />
-  <meta name="twitter:description" content="Search your shelves like CTRL+F. Works offline. One-time $1.99." />
-  <meta name="twitter:image" content="/assets/shelfscan-og.jpg" />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Shelf Scan — Camera shelf search" />
+    <meta
+      name="twitter:description"
+      content="Search your shelves like CTRL+F. Works offline. One-time $1.99."
+    />
+    <meta name="twitter:image" content="/assets/shelfscan-og.jpg" />
 
-  <!-- Schema.org -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
-    "name": "Shelf Scan",
-    "operatingSystem": "Android",
-    "applicationCategory": "UtilitiesApplication",
-    "offers": {"@type":"Offer","price":"1.99","priceCurrency":"USD"},
-    "url": "https://ulix.app/shelfscan",
-    "downloadUrl": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan",
-    "publisher": {"@type":"Organization","name":"Ulix LLC"},
-    "description": "Find books, movies, and games instantly by searching shelf text on-device. Works offline. 100% private."
-  }
-  </script>
+    <!-- Schema.org -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Shelf Scan",
+        "operatingSystem": "Android",
+        "applicationCategory": "UtilitiesApplication",
+        "offers": { "@type": "Offer", "price": "1.99", "priceCurrency": "USD" },
+        "url": "https://ulix.app/shelfscan",
+        "downloadUrl": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan",
+        "publisher": { "@type": "Organization", "name": "Ulix LLC" },
+        "description": "Find books, movies, and games instantly by searching shelf text on-device. Works offline. 100% private."
+      }
+    </script>
 
-  <style>
-    :root {
-      --bg: #FAFAFA;
-      --text: #1A1A1A;
-      --muted: #5A5A5A;
-      --card: #FFFFFF;
-      --primary: #1976D2; /* deep blue  */
-      --secondary: #26A69A; /* teal  */
-      --accent: #FFB300; /* warm gold  */
-      --line: #E0E0E0;
-      --tint: #E3F2FD; /* light blue tint */
-    }
+    <style>
+      :root {
+        --bg: #fafafa;
+        --text: #1a1a1a;
+        --muted: #5a5a5a;
+        --card: #ffffff;
+        --primary: #1976d2; /* deep blue  */
+        --line: #e0e0e0;
+        --tint: #e3f2fd; /* light blue tint */
+      }
 
-    * { box-sizing: border-box; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      color: var(--text);
-      background: var(--bg);
-      line-height: 1.5;
-    }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        font-family:
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          "Apple Color Emoji",
+          "Segoe UI Emoji";
+        color: var(--text);
+        background: var(--bg);
+        line-height: 1.5;
+      }
 
-    .container { width: min(1080px, 92vw); margin: 0 auto; }
+      .container {
+        width: min(1080px, 92vw);
+        margin: 0 auto;
+      }
 
-    /* Hero */
-    .hero { padding: clamp(28px, 6vw, 64px) 0; }
-    .hero-grid { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: clamp(20px, 4vw, 48px); align-items: center; }
-    @media (max-width: 900px) { .hero-grid { grid-template-columns: 1fr; } }
+      /* Hero */
+      .hero {
+        padding: clamp(28px, 6vw, 64px) 0;
+      }
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.05fr 0.95fr;
+        gap: clamp(20px, 4vw, 48px);
+        align-items: center;
+      }
+      @media (max-width: 900px) {
+        .hero-grid {
+          grid-template-columns: 1fr;
+        }
+      }
 
-    .eyebrow { color: var(--secondary); font-weight: 700; letter-spacing: .04em; text-transform: uppercase; font-size: .85rem; }
-    h1 { font-size: clamp(1.9rem, 3.3vw, 3rem); margin: .35rem 0 1rem; line-height: 1.1; }
-    .subhead { font-size: clamp(1rem, 1.4vw, 1.2rem); color: var(--muted); margin: 0 0 1.25rem; }
+      .eyebrow {
+        color: var(--gold);
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 0.85rem;
+      }
+      h1 {
+        font-size: clamp(1.9rem, 3.3vw, 3rem);
+        margin: 0.35rem 0 1rem;
+        line-height: 1.1;
+      }
+      .subhead {
+        font-size: clamp(1rem, 1.4vw, 1.2rem);
+        color: var(--muted);
+        margin: 0 0 1.25rem;
+      }
 
-    .cta-row { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-top: 10px; }
-    .price { background: var(--tint); color: var(--text); padding: 8px 12px; border-radius: 999px; font-weight: 600; border: 1px solid var(--line); }
+      .cta-row {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .price {
+        background: var(--tint);
+        color: var(--text);
+        padding: 8px 12px;
+        border-radius: 999px;
+        font-weight: 600;
+        border: 1px solid var(--line);
+      }
 
-    .play-badge { display: inline-flex; border-radius: 12px; overflow: hidden; box-shadow: 0 6px 20px rgba(0,0,0,.12); transition: transform .06s ease; }
-    .play-badge:hover { transform: translateY(-1px); }
-    .play-badge img { height: 54px; display: block; }
+      .play-badge {
+        display: inline-flex;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+        transition: transform 0.06s ease;
+      }
+      .play-badge:hover {
+        transform: translateY(-1px);
+      }
+      .play-badge img {
+        height: 54px;
+        display: block;
+      }
 
-    .hero-media { 
-  border-radius: 18px; 
-  overflow: hidden; 
-  background: var(--card); 
-  border: 1px solid var(--line); 
-  box-shadow: 0 10px 40px rgba(0,0,0,.08); 
-  width: clamp(320px, 35vw, 450px); /* Smaller on desktop */
-  margin-inline: auto; 
-}
+      .hero-media {
+        border-radius: 18px;
+        overflow: hidden;
+        background: var(--card);
+        border: 1px solid var(--line);
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+        width: clamp(320px, 35vw, 450px); /* Smaller on desktop */
+        margin-inline: auto;
+      }
 
+      @media (max-width: 900px) {
+        .hero-media {
+          width: clamp(280px, 85vw, 400px); /* Different sizing for mobile */
+        }
+      }
 
-@media (max-width: 900px) {
-  .hero-media {
-    width: clamp(280px, 85vw, 400px); /* Different sizing for mobile */
-  }
-}
+      .hero-media video,
+      .hero-media img {
+        display: block;
+        width: 100%; /* Fill container */
+        height: auto; /* Maintain aspect ratio */
+      }
 
-.hero-media video, .hero-media img { 
-  display: block; 
-  width: 100%; /* Fill container */
-  height: auto; /* Maintain aspect ratio */
-}
+      /* 3-step */
+      .steps {
+        padding: clamp(24px, 4vw, 40px) 0;
+        border-top: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+        background: #fff;
+      }
+      .steps-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: clamp(14px, 3vw, 26px);
+      }
+      @media (max-width: 900px) {
+        .steps-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .step {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 18px;
+      }
+      .step h3 {
+        margin: 0.25rem 0 0.35rem;
+        font-size: 1.05rem;
+      }
+      .step p {
+        margin: 0;
+        color: var(--muted);
+      }
 
-    /* 3-step */
-    .steps { padding: clamp(24px, 4vw, 40px) 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: #fff; }
-    .steps-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(14px, 3vw, 26px); }
-    @media (max-width: 900px) { .steps-grid { grid-template-columns: 1fr; } }
-    .step { background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 18px; }
-    .step h3 { margin: .25rem 0 .35rem; font-size: 1.05rem; }
-    .step p { margin: 0; color: var(--muted); }
+      /* Differentiators */
+      .diff {
+        padding: clamp(28px, 5vw, 56px) 0;
+      }
+      .diff h2 {
+        margin: 0 0 16px;
+        font-size: clamp(1.4rem, 2.2vw, 2rem);
+      }
+      .diff-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: clamp(16px, 3vw, 28px);
+      }
+      @media (max-width: 900px) {
+        .diff-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 18px;
+      }
+      .card strong {
+        color: var(--text);
+      }
+      .kicker {
+        color: var(--muted);
+        margin-top: 6px;
+      }
 
-    /* Differentiators */
-    .diff { padding: clamp(28px, 5vw, 56px) 0; }
-    .diff h2 { margin: 0 0 16px; font-size: clamp(1.4rem, 2.2vw, 2rem); }
-    .diff-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(16px, 3vw, 28px); }
-    @media (max-width: 900px) { .diff-grid { grid-template-columns: 1fr; } }
-    .card { background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 18px; }
-    .card strong { color: var(--text); }
-    .kicker { color: var(--muted); margin-top: 6px; }
+      /* Social proof */
+      .proof {
+        padding: clamp(24px, 4vw, 40px) 0;
+        background: linear-gradient(180deg, #fff 0, #fff 60%, #f6fbff 100%);
+        border-top: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+      }
+      .quotes {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+      @media (max-width: 900px) {
+        .quotes {
+          grid-template-columns: 1fr;
+        }
+      }
+      blockquote {
+        margin: 0;
+        padding: 18px;
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        font-style: italic;
+        color: var(--text);
+      }
+      .stars {
+        color: #f59e0b;
+        font-size: 1rem;
+        letter-spacing: 0.08em;
+      }
 
-    /* Social proof */
-    .proof { padding: clamp(24px, 4vw, 40px) 0; background: linear-gradient(180deg, #fff 0, #fff 60%, #f6fbff 100%); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-    .quotes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
-    @media (max-width: 900px) { .quotes { grid-template-columns: 1fr; } }
-    blockquote { margin: 0; padding: 18px; background: var(--card); border: 1px solid var(--line); border-radius: 16px; font-style: italic; color: var(--text); }
-    .stars { color: #F59E0B; font-size: 1rem; letter-spacing: .08em; }
+      /* FAQ / Objections */
+      .faq {
+        padding: clamp(28px, 5vw, 56px) 0;
+      }
+      details {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 14px 16px;
+      }
+      details + details {
+        margin-top: 10px;
+      }
+      summary {
+        font-weight: 600;
+        cursor: pointer;
+      }
+      summary::-webkit-details-marker {
+        display: none;
+      }
 
-    /* FAQ / Objections */
-    .faq { padding: clamp(28px, 5vw, 56px) 0; }
-    details { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 14px 16px; }
-    details + details { margin-top: 10px; }
-    summary { font-weight: 600; cursor: pointer; }
-    summary::-webkit-details-marker { display: none; }
+      /* Bottom CTA */
+      .bottom-cta {
+        text-align: center;
+        padding: clamp(28px, 5vw, 48px) 0;
+      }
+      .bottom-cta .tag {
+        display: inline-block;
+        background: var(--tint);
+        border: 1px solid var(--line);
+        color: var(--text);
+        padding: 6px 10px;
+        border-radius: 999px;
+        font-weight: 600;
+        margin-bottom: 10px;
+      }
 
-    /* Bottom CTA */
-    .bottom-cta { text-align: center; padding: clamp(28px, 5vw, 48px) 0; }
-    .bottom-cta .tag { display: inline-block; background: var(--tint); border: 1px solid var(--line); color: var(--text); padding: 6px 10px; border-radius: 999px; font-weight: 600; margin-bottom: 10px; }
+      /* Sticky mobile CTA */
+      .sticky-cta {
+        position: sticky;
+        bottom: 0;
+        z-index: 30;
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(6px);
+        border-top: 1px solid var(--line);
+        padding: 10px 0;
+        display: none;
+      }
+      @media (max-width: 760px) {
+        .sticky-cta {
+          display: block;
+        }
+        .play-badge img {
+          height: 48px;
+        }
+      }
 
-    /* Sticky mobile CTA */
-    .sticky-cta { position: sticky; bottom: 0; z-index: 30; background: rgba(255,255,255,.9); backdrop-filter: blur(6px); border-top: 1px solid var(--line); padding: 10px 0; display: none; }
-    @media (max-width: 760px) {
-      .sticky-cta { display: block; }
-      .play-badge img { height: 48px; }
-    }
+      /* Accessibility: reduced motion */
+      @media (prefers-reduced-motion: reduce) {
+        video {
+          animation: none !important;
+        }
+      }
 
-    /* Accessibility: reduced motion */
-    @media (prefers-reduced-motion: reduce) {
-      video { animation: none !important; }
-    }
+      /* Small helpers */
+      .icon {
+        width: 24px;
+        height: 24px;
+        color: var(--primary);
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .muted {
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="container hero" aria-label="Shelf Scan hero">
+      <div class="hero-grid">
+        <div>
+          <div class="eyebrow">Privacy‑first • Works offline</div>
+          <h1>
+            Find anything on your shelves in seconds — no organizing required.
+          </h1>
+          <p class="subhead">
+            Shelf Scan reads text on spines and covers so you can search your
+            shelves like <strong>CTRL+F</strong>. Perfect for books, movies,
+            games, and more.
+          </p>
+          <div class="cta-row">
+            <a
+              class="play-badge"
+              aria-label="Get Shelf Scan on Google Play"
+              href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="/google-play-badge.png"
+                alt="Get it on Google Play"
+                width="180"
+                height="54"
+                loading="eager"
+              />
+            </a>
+            <span class="price"
+              >One‑time $1.99 • No ads • No subscriptions</span
+            >
+          </div>
+          <p class="subhead" style="margin: 0.5rem 0 0">
+            Not for you? Google Play makes refunds quick.
+          </p>
+          <ul class="trust" role="list">
+            <li>✓ Works offline</li>
+            <li>✓ 100% private</li>
+            <li>✓ One‑time $1.99</li>
+            <li>✓ Also great for libraries and retail aisles</li>
+          </ul>
+        </div>
+        <div class="hero-media" aria-label="Shelf Scan demo video">
+          <video
+            autoplay
+            loop
+            muted
+            playsinline
+            poster="/assets/shelfscan-poster.jpg"
+            width="720"
+            height="405"
+            preload="metadata"
+          >
+            <source src="/assets/shelfscan-demo.webm" type="video/webm" />
+            <source src="/hawkingweb.mp4" type="video/mp4" />
+            <!-- Fallback image if video can't play -->
+            Sorry, your browser doesn’t support embedded videos. Here’s a demo
+            image instead.
+          </video>
+          <noscript>
+            <img
+              src="/Shelf Scan Landing Page Demo.gif"
+              alt="Shelf Scan demo"
+            />
+          </noscript>
+        </div>
+      </div>
+    </header>
 
-    /* Small helpers */
-    .icon { width: 24px; height: 24px; color: var(--primary); }
-    .row { display: flex; align-items: center; gap: 10px; }
-    .muted { color: var(--muted); }
-  </style>
-</head>
-<body>
+    <section class="steps" aria-label="How it works">
+      <div class="container">
+        <div class="steps-grid">
+          <div class="step">
+            <div class="row">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect>
+                <line x1="8" y1="2" x2="16" y2="2" />
+              </svg>
+              <h3>Open the app</h3>
+            </div>
+            <p>
+              Camera view shows your shelf instantly. No setup, no cataloging.
+            </p>
+          </div>
+          <div class="step">
+            <div class="row">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+              <h3>Type a keyword</h3>
+            </div>
+            <p>
+              Search for a title, author, or any word that appears on the spine
+              or cover.
+            </p>
+          </div>
+          <div class="step">
+            <div class="row">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 15V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9" />
+                <path d="m3 21 4.5-4.5a2.121 2.121 0 0 1 3 0L15 21" />
+                <path d="M17 21l1.5-1.5a2.121 2.121 0 0 1 3 0L23 21" />
+              </svg>
+              <h3>See it highlighted</h3>
+            </div>
+            <p>
+              Matches light up right on your shelf so you can grab it
+              immediately.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
 
-  <header class="container hero" aria-label="Shelf Scan hero">
-    <div class="hero-grid">
-      <div>
-        <div class="eyebrow">Privacy‑first • Works offline</div>
-        <h1>Find anything on your shelves in seconds — no organizing required.</h1>
-        <p class="subhead">Shelf Scan reads text on spines and covers so you can search your shelves like <strong>CTRL+F</strong>. Perfect for books, movies, games, and more.</p>
-        <div class="cta-row">
-          <a class="play-badge" aria-label="Get Shelf Scan on Google Play" href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener">
-            <img src="/google-play-badge.png" alt="Get it on Google Play" width="180" height="54" loading="eager" />
+    <section class="diff" aria-label="Why it’s different">
+      <div class="container">
+        <h2>Why Shelf Scan is different</h2>
+        <div class="diff-grid">
+          <div class="card">
+            <strong>No organizing</strong>
+            <div class="kicker">
+              Skip cataloging. Just point and search your real shelves.
+            </div>
+          </div>
+          <div class="card">
+            <strong>Works 100% offline</strong>
+            <div class="kicker">
+              Fast, reliable, and private. Nothing leaves your device.
+            </div>
+          </div>
+          <div class="card">
+            <strong>Simple one‑time price</strong>
+            <div class="kicker">
+              Just $1.99 — no ads, no subscriptions, no accounts.
+            </div>
+          </div>
+          <div class="card">
+            <strong>Library Mode</strong>
+            <div class="kicker">
+              Save photos of your shelves and search them anytime — even when
+              you’re away. Images stay on your device.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="faq" aria-label="Questions">
+      <div class="container">
+        <details>
+          <summary>Does it work in stores and libraries?</summary>
+          <p class="muted">
+            Yes, it reads visible text on spines and covers anywhere. Great for
+            finding products on retail shelves and locating items in library
+            stacks.
+          </p>
+        </details>
+        <details>
+          <summary>Is my camera feed sent to a server?</summary>
+          <p class="muted">
+            No. Shelf Scan works entirely on‑device. No accounts, no tracking,
+            no data harvesting — ever.
+          </p>
+        </details>
+        <details>
+          <summary>Refunds?</summary>
+          <p class="muted">
+            Google Play’s refund window makes trying Shelf Scan risk‑free if
+            it’s not for you.
+          </p>
+        </details>
+      </div>
+    </section>
+
+    <section class="bottom-cta" aria-label="Download">
+      <div class="container">
+        <div class="tag">Ready to find it now?</div>
+        <h2>Download Shelf Scan and search your shelves in seconds.</h2>
+        <div class="cta-row" style="justify-content: center; margin-top: 12px">
+          <a
+            class="play-badge"
+            aria-label="Get Shelf Scan on Google Play"
+            href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan"
+            target="_blank"
+            rel="noopener"
+          >
+            <img src="/google-play-badge.png" alt="Get it on Google Play" />
           </a>
           <span class="price">One‑time $1.99 • No ads • No subscriptions</span>
         </div>
-        <p class="subhead" style="margin:.5rem 0 0;">Not for you? Google Play makes refunds quick.</p>
-        <ul class="trust" role="list">
-          <li>✓ Works offline</li>
-          <li>✓ 100% private</li>
-          <li>✓ One‑time $1.99</li>
-          <li>✓ Also great for libraries and retail aisles</li>
-        </ul>
       </div>
-     <div class="hero-media" aria-label="Shelf Scan demo video">
-        <video autoplay loop muted playsinline poster="/assets/shelfscan-poster.jpg" width="720" height="405" preload="metadata">
-          <source src="/assets/shelfscan-demo.webm" type="video/webm" />
-          <source src="/hawkingweb.mp4" type="video/mp4" />
-          <!-- Fallback image if video can't play -->
-          Sorry, your browser doesn’t support embedded videos. Here’s a demo image instead.
-        </video>
-        <noscript>
-          <img src="/Shelf Scan Landing Page Demo.gif" alt="Shelf Scan demo" />
-        </noscript>
-      </div>
-    </div>
-  </header>
+    </section>
 
-  <section class="steps" aria-label="How it works">
-    <div class="container">
-      <div class="steps-grid">
-        <div class="step">
-          <div class="row">
-            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect><line x1="8" y1="2" x2="16" y2="2"/></svg>
-            <h3>Open the app</h3>
-          </div>
-          <p>Camera view shows your shelf instantly. No setup, no cataloging.</p>
-        </div>
-        <div class="step">
-          <div class="row">
-            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-            <h3>Type a keyword</h3>
-          </div>
-          <p>Search for a title, author, or any word that appears on the spine or cover.</p>
-        </div>
-        <div class="step">
-          <div class="row">
-            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9"/><path d="m3 21 4.5-4.5a2.121 2.121 0 0 1 3 0L15 21"/><path d="M17 21l1.5-1.5a2.121 2.121 0 0 1 3 0L23 21"/></svg>
-            <h3>See it highlighted</h3>
-          </div>
-          <p>Matches light up right on your shelf so you can grab it immediately.</p>
+    <div class="sticky-cta" aria-hidden="false">
+      <div
+        class="container"
+        style="
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+        "
+      >
+        <div class="row">
+          <svg
+            class="icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 6v6l4 2" />
+          </svg>
+          <strong>Find it in seconds</strong>
+          <span class="muted">— works offline</span>
         </div>
       </div>
     </div>
-  </section>
 
-  <section class="diff" aria-label="Why it’s different">
-    <div class="container">
-      <h2>Why Shelf Scan is different</h2>
-      <div class="diff-grid">
-        <div class="card">
-          <strong>No organizing</strong>
-          <div class="kicker">Skip cataloging. Just point and search your real shelves.</div>
-        </div>
-        <div class="card">
-          <strong>Works 100% offline</strong>
-          <div class="kicker">Fast, reliable, and private. Nothing leaves your device.</div>
-        </div>
-        <div class="card">
-          <strong>Simple one‑time price</strong>
-          <div class="kicker">Just $1.99 — no ads, no subscriptions, no accounts.</div>
-        </div>
-        <div class="card">
-          <strong>Library Mode</strong>
-          <div class="kicker">Save photos of your shelves and search them anytime — even when you’re away. Images stay on your device.</div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  
-
-  <section class="faq" aria-label="Questions">
-    <div class="container">
-      <details>
-        <summary>Does it work in stores and libraries?</summary>
-        <p class="muted">Yes, it reads visible text on spines and covers anywhere. Great for finding products on retail shelves and locating items in library stacks.</p>
-      </details>
-      <details>
-        <summary>Is my camera feed sent to a server?</summary>
-        <p class="muted">No. Shelf Scan works entirely on‑device. No accounts, no tracking, no data harvesting — ever.</p>
-      </details>
-      <details>
-        <summary>Refunds?</summary>
-        <p class="muted">Google Play’s refund window makes trying Shelf Scan risk‑free if it’s not for you.</p>
-      </details>
-    </div>
-  </section>
-
-  <section class="bottom-cta" aria-label="Download">
-    <div class="container">
-      <div class="tag">Ready to find it now?</div>
-      <h2>Download Shelf Scan and search your shelves in seconds.</h2>
-      <div class="cta-row" style="justify-content:center; margin-top:12px;">
-        <a class="play-badge" aria-label="Get Shelf Scan on Google Play" href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener">
-          <img src="/google-play-badge.png" alt="Get it on Google Play"/>
-        </a>
-        <span class="price">One‑time $1.99 • No ads • No subscriptions</span>
-      </div>
-    </div>
-  </section>
-
-  <div class="sticky-cta" aria-hidden="false">
-    <div class="container" style="display:flex; align-items:center; justify-content:space-between; gap:12px;">
-      <div class="row">
-        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-        <strong>Find it in seconds</strong>
-        <span class="muted">— works offline</span>
-      </div>
-    </div>
-  </div>
-
-  <footer class="container" style="padding:32px 0 56px; color:var(--muted); font-size:.9rem;">
-    Built by Ulix LLC • Privacy‑first software • <a href="/" style="color:var(--primary); text-underline-offset:2px;">ulix.app</a>
-  </footer>
+    <footer
+      class="container"
+      style="padding: 32px 0 56px; color: var(--muted); font-size: 0.9rem"
+    >
+      Built by Ulix LLC • Privacy‑first software •
+      <a href="/" style="color: var(--primary); text-underline-offset: 2px"
+        >ulix.app</a
+      >
+    </footer>
+  </body>
+</html>

--- a/shelfscan/index.html
+++ b/shelfscan/index.html
@@ -1,188 +1,310 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Shelf Scan – Find books fast. No organizing required.</title>
-  <meta name="description" content="Shelf Scan lets you search your shelves like CTRL+F. Find books, movies, and games instantly by reading spine and cover text on-device. Private, offline, no accounts." />
-  <link rel="icon" href="/favicon.ico" />
-  <meta property="og:title" content="Shelf Scan – Find books fast. No organizing required." />
-  <meta property="og:description" content="Search your shelves instantly. Works offline. 100% private. No setup, no accounts, no ads." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://ulix.app/shelfscan" />
-  <meta property="og:image" content="https://ulix.app/favicon.png" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Shelf Scan – Find books fast. No organizing required." />
-  <meta name="twitter:description" content="Search your shelves instantly. Works offline. 100% private." />
-  <meta name="twitter:image" content="https://ulix.app/favicon.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <style>
-    :root { --ulix-bg: #0b0d12; --ulix-ink: #eaeef7; --ulix-accent: #5eead4; }
-    .ulix-bg { background: var(--ulix-bg); }
-    .ulix-ink { color: var(--ulix-ink); }
-    .ulix-muted { color: #b7c0d1; }
-    .ulix-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
-    .glow { box-shadow: 0 8px 30px rgba(94,234,212,0.25); }
-    /* Responsive 16:9 video embed without extra plugins */
-    .video-wrap { position: relative; width: 100%; padding-top: 56.25%; border-radius: 1rem; overflow: hidden; }
-    .video-wrap iframe { position: absolute; inset: 0; width: 100%; height: 100%; }
-  </style>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
-    "name": "Shelf Scan",
-    "operatingSystem": "Android",
-    "applicationCategory": "http://schema.org/UtilitiesApplication",
-    "offers": {"@type":"Offer","price":"0","priceCurrency":"USD"},
-    "url": "https://ulix.app/shelfscan",
-    "downloadUrl": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan",
-    "publisher": {"@type":"Organization","name":"Ulix LLC"},
-    "description": "Find books, movies, and games instantly by searching shelf text on-device. Works offline. No accounts, no ads.",
-    "screenshot": [
-      "https://ulix.app/shelfscan/screen-1.png",
-      "https://ulix.app/shelfscan/screen-2.png",
-      "https://ulix.app/shelfscan/screen-3.png"
-    ]
-  }
-  </script>
-</head>
-<body class="ulix-bg ulix-ink antialiased">
-  <!-- Header -->
-  <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
-    <a href="/" class="flex items-center gap-3 group">
-      <img src="https://ulix.app/favicon.png" alt="Ulix" class="w-8 h-8" />
-      <span class="font-semibold tracking-tight group-hover:opacity-90">Ulix</span>
-    </a>
-    <nav class="hidden md:flex items-center gap-6 text-sm">
-      <a href="/" class="hover:opacity-90">Apps</a>
-      <a href="/shelfscanprivacy.html" class="hover:opacity-90">Privacy</a>
-      <a href="/about.html" class="hover:opacity-90">About</a>
-    </nav>
-  </header>
-
-  <!-- Hero -->
-  <section class="max-w-6xl mx-auto px-4 pt-4 pb-10 md:pb-16">
-    <div class="grid md:grid-cols-2 gap-10 items-center">
-      <div>
-        <h1 class="text-3xl md:text-5xl font-semibold leading-tight">
-          Find your books fast. <span class="text-teal-300">No organizing required.</span>
-        </h1>
-        <p class="ulix-muted mt-4 text-lg">Shelf Scan lets you search your shelves like <span class="font-semibold">CTRL+F</span>—instantly locating books, movies, and games by reading spine and cover text <span class="font-semibold">entirely on your device</span>.</p>
-        <div class="flex flex-wrap items-center gap-4 mt-6">
-          <a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" class="inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/15 transition glow">
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5"><path fill="currentColor" d="M1.5 3.75a.75.75 0 0 1 .75-.75h11.25a.75.75 0 0 1 .75.75v5.25h7.5a.75.75 0 0 1 .53 1.28l-9 9a.75.75 0 0 1-1.28-.53V12H2.25a.75.75 0 0 1-.75-.75V3.75Z"/></svg>
-            <span class="font-medium">Get it on Google Play</span>
-          </a>
-        </div>
-        <p class="mt-4 text-sm ulix-muted">Works completely offline • 100% private • No accounts, no ads</p>
-      </div>
-      <div>
-        <div class="video-wrap ulix-card">
-          <iframe src="https://www.youtube.com/embed/BnrCHmJDmOI" title="Shelf Scan Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Key Benefits -->
-  <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
-    <div class="grid md:grid-cols-3 gap-6">
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="text-xl font-semibold">Instant search</h3>
-        <p class="ulix-muted mt-2">Point your camera at your shelves and type a keyword. Find titles in seconds without cataloging first.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="text-xl font-semibold">Private & offline</h3>
-        <p class="ulix-muted mt-2">All text processing happens on your device. Nothing is uploaded, stored, or shared.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="text-xl font-semibold">Zero setup</h3>
-        <p class="ulix-muted mt-2">No accounts, no spreadsheets, no barcode scanners. Just open the app and search.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- How it works -->
-  <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
-    <h2 class="text-2xl md:text-3xl font-semibold">How it works</h2>
-    <div class="grid md:grid-cols-3 gap-6 mt-6">
-      <div class="ulix-card rounded-2xl p-6">
-        <p class="text-sm uppercase tracking-wide ulix-muted">Step 1</p>
-        <h3 class="text-lg font-semibold mt-1">Open & point</h3>
-        <p class="ulix-muted mt-2">Open Shelf Scan and point your camera at your shelves.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <p class="text-sm uppercase tracking-wide ulix-muted">Step 2</p>
-        <h3 class="text-lg font-semibold mt-1">Type a keyword</h3>
-        <p class="ulix-muted mt-2">Enter a title, author, or unique word you remember.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <p class="text-sm uppercase tracking-wide ulix-muted">Step 3</p>
-        <h3 class="text-lg font-semibold mt-1">Find instantly</h3>
-        <p class="ulix-muted mt-2">Results highlight where to look so you can grab the right item fast.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- Screenshots -->
-  <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
-    <h2 class="text-2xl md:text-3xl font-semibold">See it in action</h2>
-    <div class="grid md:grid-cols-3 gap-6 mt-6">
-      <img src="/shelfscan/screen-1.png" alt="Search screen" class="rounded-xl ulix-card" />
-      <img src="/shelfscan/screen-2.png" alt="Highlighted result" class="rounded-xl ulix-card" />
-      <img src="/shelfscan/screen-3.png" alt="Find by keyword" class="rounded-xl ulix-card" />
-    </div>
-  </section>
-
-  <!-- Privacy -->
-  <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
-    <div class="ulix-card rounded-2xl p-6 md:p-8">
-      <h2 class="text-2xl md:text-3xl font-semibold">Private by design</h2>
-      <p class="ulix-muted mt-2">Shelf Scan processes text locally on your device. We don’t collect analytics, use trackers, or require accounts. Your shelves stay yours.</p>
-    </div>
-  </section>
-
-  <!-- FAQ -->
-  <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
-    <h2 class="text-2xl md:text-3xl font-semibold">Frequently asked</h2>
-    <div class="mt-6 grid md:grid-cols-2 gap-6">
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="font-semibold">Does it work in libraries and stores?</h3>
-        <p class="ulix-muted mt-2">Yes. Shelf Scan works anywhere there’s shelf text—your home, libraries, or retail aisles.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="font-semibold">Does it need internet?</h3>
-        <p class="ulix-muted mt-2">No. It works offline. An internet connection is only needed to download the app from Google Play.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="font-semibold">What about privacy?</h3>
-        <p class="ulix-muted mt-2">We don’t collect or transmit your data. Everything stays local to your device.</p>
-      </div>
-      <div class="ulix-card rounded-2xl p-6">
-        <h3 class="font-semibold">What devices are supported?</h3>
-        <p class="ulix-muted mt-2">Android 7.0 (Nougat) and up. iOS is planned.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- CTA -->
-  <section class="max-w-6xl mx-auto px-4 py-10 md:py-16">
-    <div class="ulix-card rounded-2xl p-8 flex flex-col md:flex-row items-center justify-between gap-6">
-      <div>
-        <h2 class="text-2xl md:text-3xl font-semibold">Ready to find things faster?</h2>
-        <p class="ulix-muted mt-2">Grab Shelf Scan on Google Play.</p>
-      </div>
-      <a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" class="inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/15 transition glow">
-        <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5"><path fill="currentColor" d="M1.5 3.75a.75.75 0 0 1 .75-.75h11.25a.75.75 0 0 1 .75.75v5.25h7.5a.75.75 0 0 1 .53 1.28l-9 9a.75.75 0 0 1-1.28-.53V12H2.25a.75.75 0 0 1-.75-.75V3.75Z"/></svg>
-        <span class="font-medium">Get it on Google Play</span>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Shelf Scan – Find books fast. No organizing required.</title>
+    <meta
+      name="description"
+      content="Shelf Scan lets you search your shelves like CTRL+F. Find books, movies, and games instantly by reading spine and cover text on-device. Private, offline, no accounts."
+    />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+    <meta
+      property="og:title"
+      content="Shelf Scan – Find books fast. No organizing required."
+    />
+    <meta
+      property="og:description"
+      content="Search your shelves instantly. Works offline. 100% private. No setup, no accounts, no ads."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://ulix.app/shelfscan" />
+    <meta property="og:image" content="https://ulix.app/favicon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Shelf Scan – Find books fast. No organizing required."
+    />
+    <meta
+      name="twitter:description"
+      content="Search your shelves instantly. Works offline. 100% private."
+    />
+    <meta name="twitter:image" content="https://ulix.app/favicon.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      :root {
+        --ulix-bg: #0b0d12;
+        --ulix-ink: #eaeef7;
+      }
+      .ulix-bg {
+        background: var(--ulix-bg);
+      }
+      .ulix-ink {
+        color: var(--ulix-ink);
+      }
+      .ulix-muted {
+        color: #b7c0d1;
+      }
+      .ulix-card {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+      .glow {
+        box-shadow: 0 8px 30px color-mix(in srgb, var(--gold), transparent 75%);
+      }
+      /* Responsive 16:9 video embed without extra plugins */
+      .video-wrap {
+        position: relative;
+        width: 100%;
+        padding-top: 56.25%;
+        border-radius: 1rem;
+        overflow: hidden;
+      }
+      .video-wrap iframe {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Shelf Scan",
+        "operatingSystem": "Android",
+        "applicationCategory": "http://schema.org/UtilitiesApplication",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "url": "https://ulix.app/shelfscan",
+        "downloadUrl": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan",
+        "publisher": { "@type": "Organization", "name": "Ulix LLC" },
+        "description": "Find books, movies, and games instantly by searching shelf text on-device. Works offline. No accounts, no ads.",
+        "screenshot": [
+          "https://ulix.app/shelfscan/screen-1.png",
+          "https://ulix.app/shelfscan/screen-2.png",
+          "https://ulix.app/shelfscan/screen-3.png"
+        ]
+      }
+    </script>
+  </head>
+  <body class="ulix-bg ulix-ink antialiased">
+    <!-- Header -->
+    <header
+      class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between"
+    >
+      <a href="/" class="flex items-center gap-3 group">
+        <img src="https://ulix.app/favicon.png" alt="Ulix" class="w-8 h-8" />
+        <span class="font-semibold tracking-tight group-hover:opacity-90"
+          >Ulix</span
+        >
       </a>
-    </div>
-  </section>
+      <nav class="hidden md:flex items-center gap-6 text-sm">
+        <a href="/" class="hover:opacity-90">Apps</a>
+        <a href="/shelfscanprivacy.html" class="hover:opacity-90">Privacy</a>
+        <a href="/about.html" class="hover:opacity-90">About</a>
+      </nav>
+    </header>
 
-  <!-- Footer -->
-  <footer class="max-w-6xl mx-auto px-4 py-10">
-    <div class="text-sm ulix-muted">© 2025 Ulix. Precision Tools for Modern Odysseys.</div>
-  </footer>
-</body>
+    <!-- Hero -->
+    <section class="max-w-6xl mx-auto px-4 pt-4 pb-10 md:pb-16">
+      <div class="grid md:grid-cols-2 gap-10 items-center">
+        <div>
+          <h1 class="text-3xl md:text-5xl font-semibold leading-tight">
+            Find your books fast.
+            <span class="text-[var(--gold)]">No organizing required.</span>
+          </h1>
+          <p class="ulix-muted mt-4 text-lg">
+            Shelf Scan lets you search your shelves like
+            <span class="font-semibold">CTRL+F</span>—instantly locating books,
+            movies, and games by reading spine and cover text
+            <span class="font-semibold">entirely on your device</span>.
+          </p>
+          <div class="flex flex-wrap items-center gap-4 mt-6">
+            <a
+              href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan"
+              class="inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/15 transition glow"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5">
+                <path
+                  fill="currentColor"
+                  d="M1.5 3.75a.75.75 0 0 1 .75-.75h11.25a.75.75 0 0 1 .75.75v5.25h7.5a.75.75 0 0 1 .53 1.28l-9 9a.75.75 0 0 1-1.28-.53V12H2.25a.75.75 0 0 1-.75-.75V3.75Z"
+                />
+              </svg>
+              <span class="font-medium">Get it on Google Play</span>
+            </a>
+          </div>
+          <p class="mt-4 text-sm ulix-muted">
+            Works completely offline • 100% private • No accounts, no ads
+          </p>
+        </div>
+        <div>
+          <div class="video-wrap ulix-card">
+            <iframe
+              src="https://www.youtube.com/embed/BnrCHmJDmOI"
+              title="Shelf Scan Demo"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Key Benefits -->
+    <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+      <div class="grid md:grid-cols-3 gap-6">
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="text-xl font-semibold">Instant search</h3>
+          <p class="ulix-muted mt-2">
+            Point your camera at your shelves and type a keyword. Find titles in
+            seconds without cataloging first.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="text-xl font-semibold">Private & offline</h3>
+          <p class="ulix-muted mt-2">
+            All text processing happens on your device. Nothing is uploaded,
+            stored, or shared.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="text-xl font-semibold">Zero setup</h3>
+          <p class="ulix-muted mt-2">
+            No accounts, no spreadsheets, no barcode scanners. Just open the app
+            and search.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+      <h2 class="text-2xl md:text-3xl font-semibold">How it works</h2>
+      <div class="grid md:grid-cols-3 gap-6 mt-6">
+        <div class="ulix-card rounded-2xl p-6">
+          <p class="text-sm uppercase tracking-wide ulix-muted">Step 1</p>
+          <h3 class="text-lg font-semibold mt-1">Open & point</h3>
+          <p class="ulix-muted mt-2">
+            Open Shelf Scan and point your camera at your shelves.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <p class="text-sm uppercase tracking-wide ulix-muted">Step 2</p>
+          <h3 class="text-lg font-semibold mt-1">Type a keyword</h3>
+          <p class="ulix-muted mt-2">
+            Enter a title, author, or unique word you remember.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <p class="text-sm uppercase tracking-wide ulix-muted">Step 3</p>
+          <h3 class="text-lg font-semibold mt-1">Find instantly</h3>
+          <p class="ulix-muted mt-2">
+            Results highlight where to look so you can grab the right item fast.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Screenshots -->
+    <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+      <h2 class="text-2xl md:text-3xl font-semibold">See it in action</h2>
+      <div class="grid md:grid-cols-3 gap-6 mt-6">
+        <img
+          src="/shelfscan/screen-1.png"
+          alt="Search screen"
+          class="rounded-xl ulix-card"
+        />
+        <img
+          src="/shelfscan/screen-2.png"
+          alt="Highlighted result"
+          class="rounded-xl ulix-card"
+        />
+        <img
+          src="/shelfscan/screen-3.png"
+          alt="Find by keyword"
+          class="rounded-xl ulix-card"
+        />
+      </div>
+    </section>
+
+    <!-- Privacy -->
+    <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+      <div class="ulix-card rounded-2xl p-6 md:p-8">
+        <h2 class="text-2xl md:text-3xl font-semibold">Private by design</h2>
+        <p class="ulix-muted mt-2">
+          Shelf Scan processes text locally on your device. We don’t collect
+          analytics, use trackers, or require accounts. Your shelves stay yours.
+        </p>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+      <h2 class="text-2xl md:text-3xl font-semibold">Frequently asked</h2>
+      <div class="mt-6 grid md:grid-cols-2 gap-6">
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="font-semibold">Does it work in libraries and stores?</h3>
+          <p class="ulix-muted mt-2">
+            Yes. Shelf Scan works anywhere there’s shelf text—your home,
+            libraries, or retail aisles.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="font-semibold">Does it need internet?</h3>
+          <p class="ulix-muted mt-2">
+            No. It works offline. An internet connection is only needed to
+            download the app from Google Play.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="font-semibold">What about privacy?</h3>
+          <p class="ulix-muted mt-2">
+            We don’t collect or transmit your data. Everything stays local to
+            your device.
+          </p>
+        </div>
+        <div class="ulix-card rounded-2xl p-6">
+          <h3 class="font-semibold">What devices are supported?</h3>
+          <p class="ulix-muted mt-2">
+            Android 7.0 (Nougat) and up. iOS is planned.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="max-w-6xl mx-auto px-4 py-10 md:py-16">
+      <div
+        class="ulix-card rounded-2xl p-8 flex flex-col md:flex-row items-center justify-between gap-6"
+      >
+        <div>
+          <h2 class="text-2xl md:text-3xl font-semibold">
+            Ready to find things faster?
+          </h2>
+          <p class="ulix-muted mt-2">Grab Shelf Scan on Google Play.</p>
+        </div>
+        <a
+          href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan"
+          class="inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-white/10 hover:bg-white/15 transition glow"
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5">
+            <path
+              fill="currentColor"
+              d="M1.5 3.75a.75.75 0 0 1 .75-.75h11.25a.75.75 0 0 1 .75.75v5.25h7.5a.75.75 0 0 1 .53 1.28l-9 9a.75.75 0 0 1-1.28-.53V12H2.25a.75.75 0 0 1-.75-.75V3.75Z"
+            />
+          </svg>
+          <span class="font-medium">Get it on Google Play</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="max-w-6xl mx-auto px-4 py-10">
+      <div class="text-sm ulix-muted">
+        © 2025 Ulix. Precision Tools for Modern Odysseys.
+      </div>
+    </footer>
+  </body>
 </html>

--- a/shelfscanprivacy.html
+++ b/shelfscanprivacy.html
@@ -1,52 +1,79 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/assets/styles.css" />
     <title>Shelf Scan Privacy Policy</title>
     <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            margin: 0;
-            padding: 2rem;
-            line-height: 1.6;
-            background-color: #ffffff;
-            color: #1a1a1a;
-        }
-        main {
-            max-width: 720px;
-            margin: 0 auto;
-        }
-        h1 {
-            font-size: 2rem;
-            margin-bottom: 1rem;
-        }
-        p {
-            margin-bottom: 1rem;
-        }
-        footer {
-            margin-top: 3rem;
-            font-size: 0.9rem;
-            color: #888;
-            text-align: center;
-        }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.6;
+        background-color: #ffffff;
+        color: var(--navy-blue);
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+        color: var(--gold);
+      }
+      p {
+        margin-bottom: 1rem;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: var(--gold);
+        text-align: center;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <main>
-        <h1>Shelf Scan Privacy Policy</h1>
-        <p><strong>Shelf Scan</strong> is built to help you search your shelves without compromising your privacy. Here's how your data is handled:</p>
-        <ul>
-            <li>Captured images and recognized text are saved <strong>locally</strong> on your device in the app’s private storage.</li>
-            <li>No personal data is collected or transmitted. The app functions entirely <strong>offline</strong>.</li>
-            <li>There are <strong>no analytics, advertising, or third-party integrations</strong>.</li>
-            <li>You may choose to export or share your saved library using Android’s standard share features. This is completely optional and controlled by you.</li>
-            <li>The app requests access to your <strong>camera</strong> (to take photos for OCR) and uses <strong>vibration</strong> (for haptic feedback when scanning).</li>
-        </ul>
-        <p>Your data stays on your device unless you decide to share it. Shelf Scan is designed to work powerfully without ever needing an internet connection.</p>
+      <h1>Shelf Scan Privacy Policy</h1>
+      <p>
+        <strong>Shelf Scan</strong> is built to help you search your shelves
+        without compromising your privacy. Here's how your data is handled:
+      </p>
+      <ul>
+        <li>
+          Captured images and recognized text are saved
+          <strong>locally</strong> on your device in the app’s private storage.
+        </li>
+        <li>
+          No personal data is collected or transmitted. The app functions
+          entirely <strong>offline</strong>.
+        </li>
+        <li>
+          There are
+          <strong>no analytics, advertising, or third-party integrations</strong
+          >.
+        </li>
+        <li>
+          You may choose to export or share your saved library using Android’s
+          standard share features. This is completely optional and controlled by
+          you.
+        </li>
+        <li>
+          The app requests access to your <strong>camera</strong> (to take
+          photos for OCR) and uses <strong>vibration</strong> (for haptic
+          feedback when scanning).
+        </li>
+      </ul>
+      <p>
+        Your data stays on your device unless you decide to share it. Shelf Scan
+        is designed to work powerfully without ever needing an internet
+        connection.
+      </p>
     </main>
-    <footer>
-        Last updated: August 1, 2025
-    </footer>
-</body>
+    <footer>Last updated: August 1, 2025</footer>
+  </body>
 </html>

--- a/trackanalysisprivacy.html
+++ b/trackanalysisprivacy.html
@@ -1,53 +1,80 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/assets/styles.css" />
     <title>Track Analysis Privacy Policy</title>
     <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            margin: 0;
-            padding: 2rem;
-            line-height: 1.6;
-            background-color: #ffffff;
-            color: #1a1a1a;
-        }
-        main {
-            max-width: 720px;
-            margin: 0 auto;
-        }
-        h1 {
-            font-size: 2rem;
-            margin-bottom: 1rem;
-        }
-        p {
-            margin-bottom: 1rem;
-        }
-        footer {
-            margin-top: 3rem;
-            font-size: 0.9rem;
-            color: #888;
-            text-align: center;
-        }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.6;
+        background-color: #ffffff;
+        color: var(--navy-blue);
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+        color: var(--gold);
+      }
+      p {
+        margin-bottom: 1rem;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: var(--gold);
+        text-align: center;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <main>
-        <h1>Track Analysis Privacy Policy</h1>
-        <p><strong>Track Analysis</strong> is a personal tracking app designed with privacy in mind. Here's how your data is handled:</p>
-        <ul>
-            <li>All data you enter—such as event type, details, and timestamps—is stored <strong>locally on your device</strong>.</li>
-            <li>No data is collected, transmitted, or stored by us.</li>
-            <li>The app includes <strong>no advertising, no analytics, and no third-party integrations</strong>.</li>
-            <li>The only optional export is a CSV file saved in your app’s private storage. You may share it manually using Android's standard sharing options.</li>
-            <li>The app does <strong>not</strong> request access to your location, contacts, network, or other device features.</li>
-            <li>A disclaimer in the app reminds users that it is for personal use only and is <strong>not medical advice</strong>.</li>
-        </ul>
-        <p>You remain in full control of your data. Nothing leaves your device unless you choose to export and share it.</p>
+      <h1>Track Analysis Privacy Policy</h1>
+      <p>
+        <strong>Track Analysis</strong> is a personal tracking app designed with
+        privacy in mind. Here's how your data is handled:
+      </p>
+      <ul>
+        <li>
+          All data you enter—such as event type, details, and timestamps—is
+          stored <strong>locally on your device</strong>.
+        </li>
+        <li>No data is collected, transmitted, or stored by us.</li>
+        <li>
+          The app includes
+          <strong
+            >no advertising, no analytics, and no third-party
+            integrations</strong
+          >.
+        </li>
+        <li>
+          The only optional export is a CSV file saved in your app’s private
+          storage. You may share it manually using Android's standard sharing
+          options.
+        </li>
+        <li>
+          The app does <strong>not</strong> request access to your location,
+          contacts, network, or other device features.
+        </li>
+        <li>
+          A disclaimer in the app reminds users that it is for personal use only
+          and is <strong>not medical advice</strong>.
+        </li>
+      </ul>
+      <p>
+        You remain in full control of your data. Nothing leaves your device
+        unless you choose to export and share it.
+      </p>
     </main>
-    <footer>
-        Last updated: August 1, 2025
-    </footer>
-</body>
+    <footer>Last updated: August 1, 2025</footer>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce `--navy-blue` and `--gold` tokens in a shared `assets/styles.css`
- update about, Shelf Scan, Android landing, and privacy pages to use the shared palette
- swap Tailwind and custom styles to reference the new color variables

## Testing
- `npx prettier --check about.html gutenprivacy.html keepclipprivacypolicy.html shelfscan/android.html shelfscan/index.html shelfscanprivacy.html trackanalysisprivacy.html assets/styles.css`


------
https://chatgpt.com/codex/tasks/task_e_689e1f31ef8c832f98559c8206daa465