### PR TITLE
feat: add reusable header and footer partials

### DIFF
--- a/about.html
+++ b/about.html
@@ -50,20 +50,7 @@
     </style>
   </head>
   <body class="ulix-bg ulix-ink antialiased">
-    <header
-      class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between"
-    >
-      <a href="/" class="flex items-center gap-3 group">
-        <img src="/favicon.png" alt="Ulix" class="w-8 h-8" />
-        <span class="font-semibold tracking-tight group-hover:opacity-90"
-          >Ulix</span
-        >
-      </a>
-      <nav class="hidden md:flex items-center gap-6 text-sm">
-        <a href="/" class="hover:opacity-90">Apps</a>
-        <a href="/about.html" class="hover:opacity-90 font-semibold">About</a>
-      </nav>
-    </header>
+    <div data-include="/partials/header.html"></div>
 
     <section class="max-w-4xl mx-auto px-4 py-10 md:py-16">
       <h1 class="text-3xl md:text-5xl font-semibold leading-tight">
@@ -107,10 +94,7 @@
       </div>
     </section>
 
-    <footer class="max-w-6xl mx-auto px-4 py-10">
-      <div class="text-sm ulix-muted">
-        © 2025 Ulix. Precision Tools for Modern Odysseys.
-      </div>
-    </footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>

--- a/assets/include.js
+++ b/assets/include.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-include]').forEach(el => {
+    fetch(el.getAttribute('data-include'))
+      .then(response => response.text())
+      .then(html => {
+        el.innerHTML = html;
+      });
+  });
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2,3 +2,30 @@
   --navy-blue: #1a2332;
   --gold: #d4af37;
 }
+
+.site-header,
+.site-footer {
+  background: var(--navy-blue);
+  color: var(--gold);
+}
+
+.site-header nav {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.site-header a {
+  color: var(--gold);
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.site-header a:hover {
+  text-decoration: underline;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem 1rem;
+}

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+    <title>Contact – Ulix</title>
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.6;
+        background-color: #ffffff;
+        color: var(--navy-blue);
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+        color: var(--gold);
+      }
+    </style>
+  </head>
+  <body>
+    <div data-include="/partials/header.html"></div>
+    <main>
+      <h1>Contact</h1>
+      <p>
+        Reach us at <span id="email"></span>.
+        <noscript>hello [at] ulix [dot] app</noscript>
+      </p>
+    </main>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
+    <script>
+      (function () {
+        const user = String.fromCharCode(104, 101, 108, 108, 111);
+        const domain = String.fromCharCode(117, 108, 105, 120, 46, 97, 112, 112);
+        const email = `${user}@${domain}`;
+        const link = document.createElement('a');
+        link.href = `mailto:${email}`;
+        link.textContent = email;
+        link.style.color = 'var(--gold)';
+        document.getElementById('email').appendChild(link);
+      })();
+    </script>
+  </body>
+</html>

--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -28,15 +28,10 @@
       p {
         margin-bottom: 1rem;
       }
-      footer {
-        margin-top: 3rem;
-        font-size: 0.9rem;
-        color: var(--gold);
-        text-align: center;
-      }
     </style>
   </head>
   <body>
+    <div data-include="/partials/header.html"></div>
     <main>
       <h1>Guten Privacy Policy</h1>
       <p>
@@ -77,6 +72,7 @@
         complete control over your data.
       </p>
     </main>
-    <footer>Last updated: August 5, 2025</footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ulix - Precision Tools for Modern Odysseys</title>
     <link rel="icon" href="/favicon.png" type="image/png">
+    <link rel="stylesheet" href="/assets/styles.css">
     <style>
         * {
             margin: 0;
@@ -223,6 +224,7 @@
     </style>
 </head>
 <body>
+    <div data-include="/partials/header.html"></div>
     <!-- Hero Section -->
     <section class="hero">
         <div class="logo-container">
@@ -337,15 +339,9 @@
 
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-        <div class="footer-content">
-            <p><strong>Ulix</strong></p>
-            <p class="tagline">Precision Tools for Modern Odysseys</p>
-            <p>&copy; 2025 Ulix. All rights reserved.</p>
-        </div>
-    </footer>
+    <div data-include="/partials/footer.html"></div>
 
+    <script src="/assets/include.js"></script>
     <script>
         // Smooth scrolling for the CTA button
         document.querySelector('.cta-button').addEventListener('click', function(e) {

--- a/keepclipprivacypolicy.html
+++ b/keepclipprivacypolicy.html
@@ -28,15 +28,10 @@
       p {
         margin-bottom: 1rem;
       }
-      footer {
-        margin-top: 3rem;
-        font-size: 0.9rem;
-        color: var(--gold);
-        text-align: center;
-      }
     </style>
   </head>
   <body>
+    <div data-include="/partials/header.html"></div>
     <main>
       <h1>Keep Clip Privacy Policy</h1>
       <p>
@@ -78,6 +73,7 @@
         with minimal permissions and no external data sharing.
       </p>
     </main>
-    <footer>Last updated: August 5, 2025</footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+  <p>&copy; 2025 Ulix. Precision Tools for Modern Odysseys.</p>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,8 @@
+<header class="site-header">
+  <nav>
+    <a href="/">Home</a>
+    <a href="/#apps">Apps</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </nav>
+</header>

--- a/shelfscan/android.html
+++ b/shelfscan/android.html
@@ -349,6 +349,7 @@
     </style>
   </head>
   <body>
+    <div data-include="/partials/header.html"></div>
     <header class="container hero" aria-label="Shelf Scan hero">
       <div class="hero-grid">
         <div>
@@ -600,14 +601,7 @@
       </div>
     </div>
 
-    <footer
-      class="container"
-      style="padding: 32px 0 56px; color: var(--muted); font-size: 0.9rem"
-    >
-      Built by Ulix LLC • Privacy‑first software •
-      <a href="/" style="color: var(--primary); text-underline-offset: 2px"
-        >ulix.app</a
-      >
-    </footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>

--- a/shelfscan/index.html
+++ b/shelfscan/index.html
@@ -89,22 +89,7 @@
     </script>
   </head>
   <body class="ulix-bg ulix-ink antialiased">
-    <!-- Header -->
-    <header
-      class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between"
-    >
-      <a href="/" class="flex items-center gap-3 group">
-        <img src="https://ulix.app/favicon.png" alt="Ulix" class="w-8 h-8" />
-        <span class="font-semibold tracking-tight group-hover:opacity-90"
-          >Ulix</span
-        >
-      </a>
-      <nav class="hidden md:flex items-center gap-6 text-sm">
-        <a href="/" class="hover:opacity-90">Apps</a>
-        <a href="/shelfscanprivacy.html" class="hover:opacity-90">Privacy</a>
-        <a href="/about.html" class="hover:opacity-90">About</a>
-      </nav>
-    </header>
+    <div data-include="/partials/header.html"></div>
 
     <!-- Hero -->
     <section class="max-w-6xl mx-auto px-4 pt-4 pb-10 md:pb-16">
@@ -300,11 +285,7 @@
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="max-w-6xl mx-auto px-4 py-10">
-      <div class="text-sm ulix-muted">
-        © 2025 Ulix. Precision Tools for Modern Odysseys.
-      </div>
-    </footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>

--- a/shelfscanprivacy.html
+++ b/shelfscanprivacy.html
@@ -28,15 +28,10 @@
       p {
         margin-bottom: 1rem;
       }
-      footer {
-        margin-top: 3rem;
-        font-size: 0.9rem;
-        color: var(--gold);
-        text-align: center;
-      }
     </style>
   </head>
   <body>
+    <div data-include="/partials/header.html"></div>
     <main>
       <h1>Shelf Scan Privacy Policy</h1>
       <p>
@@ -74,6 +69,7 @@
         connection.
       </p>
     </main>
-    <footer>Last updated: August 1, 2025</footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>

--- a/trackanalysisprivacy.html
+++ b/trackanalysisprivacy.html
@@ -28,15 +28,10 @@
       p {
         margin-bottom: 1rem;
       }
-      footer {
-        margin-top: 3rem;
-        font-size: 0.9rem;
-        color: var(--gold);
-        text-align: center;
-      }
     </style>
   </head>
   <body>
+    <div data-include="/partials/header.html"></div>
     <main>
       <h1>Track Analysis Privacy Policy</h1>
       <p>
@@ -75,6 +70,7 @@
         unless you choose to export and share it.
       </p>
     </main>
-    <footer>Last updated: August 1, 2025</footer>
+    <div data-include="/partials/footer.html"></div>
+    <script src="/assets/include.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add shared header and footer partials styled with navy and gold
- load partials across pages via small include script
- add basic contact page with obfuscated hello@ulix.app address

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e21a84a1c832faaa954b50135983c