### PR TITLE
refactor: centralize styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,28 +26,6 @@
     />
     <meta name="twitter:image" content="https://ulix.app/favicon.png" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      :root {
-        --ulix-bg: #0b0d12;
-        --ulix-ink: #eaeef7;
-      }
-      .ulix-bg {
-        background: var(--ulix-bg);
-      }
-      .ulix-ink {
-        color: var(--ulix-ink);
-      }
-      .ulix-muted {
-        color: #b7c0d1;
-      }
-      .ulix-card {
-        background: rgba(255, 255, 255, 0.04);
-        border: 1px solid rgba(255, 255, 255, 0.08);
-      }
-      .glow {
-        box-shadow: 0 8px 30px color-mix(in srgb, var(--gold), transparent 75%);
-      }
-    </style>
   </head>
   <body class="ulix-bg ulix-ink antialiased">
     <div data-include="/partials/header.html"></div>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,8 +1,28 @@
+/* Brand Colors */
 :root {
   --navy-blue: #1a2332;
   --gold: #d4af37;
+  --cream: #f8f9fa;
+  --white: #ffffff;
+  --dark-text: #2c3e50;
+  --ulix-bg: #0b0d12;
+  --ulix-ink: #eaeef7;
 }
 
+/* Typography */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Layout */
 .site-header,
 .site-footer {
   background: var(--navy-blue);
@@ -28,4 +48,319 @@
 .site-footer {
   text-align: center;
   padding: 2rem 1rem;
+}
+
+/* Hero Section */
+.hero {
+  background: #011530;
+  color: var(--cream);
+  padding: 20px 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.logo-container {
+  margin-bottom: 40px;
+}
+
+.main-logo {
+  width: 40vw;
+  max-width: 500px;
+  min-width: 300px;
+  height: auto;
+  margin: 0 auto 20px;
+}
+
+.hero h1 {
+  font-size: 3.5rem;
+  font-weight: bold;
+  color: var(--gold);
+  margin-bottom: 20px;
+  letter-spacing: 2px;
+}
+
+.hero .tagline {
+  font-size: 1.3rem;
+  margin-bottom: 30px;
+  color: var(--cream);
+  font-weight: 300;
+  letter-spacing: 1px;
+}
+
+.cta-button {
+  background: var(--gold);
+  color: var(--navy-blue);
+  padding: 15px 35px;
+  border: none;
+  border-radius: 30px;
+  font-size: 1.1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.cta-button:hover {
+  background: #e6c04a;
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(212, 175, 55, 0.3);
+}
+
+.hidden {
+  display: none;
+}
+
+/* Apps Section */
+.apps-section {
+  background: var(--cream);
+  padding: 80px 20px;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+.section-header h2 {
+  font-size: 2.5rem;
+  color: var(--navy-blue);
+  margin-bottom: 15px;
+  font-weight: bold;
+}
+
+.section-header p {
+  font-size: 1.2rem;
+  color: var(--dark-text);
+}
+
+.app-note {
+  font-size: 1rem;
+  color: var(--dark-text);
+  opacity: 0.7;
+  margin-top: 10px;
+}
+
+.apps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 30px;
+  margin-top: 50px;
+}
+
+.app-card {
+  background: var(--white);
+  padding: 30px;
+  border-radius: 15px;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  border: 2px solid transparent;
+}
+
+.app-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+  border-color: var(--gold);
+}
+
+.app-icon {
+  width: 80px;
+  height: 80px;
+  border-radius: 15px;
+  margin: 0 auto 25px;
+  object-fit: cover;
+  display: block;
+}
+
+.status-badge {
+  display: block;
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  margin: 0 auto 15px;
+  width: fit-content;
+  white-space: nowrap;
+}
+
+.status-live {
+  background: #3498db;
+  color: white;
+}
+
+.status-development {
+  background: #2c3e50;
+  color: white;
+}
+
+.app-card h3 {
+  font-size: 1.5rem;
+  color: var(--navy-blue);
+  margin-bottom: 15px;
+  font-weight: bold;
+}
+
+.app-description {
+  color: var(--dark-text);
+  margin: 15px 0;
+  font-size: 1rem;
+}
+
+.no-margin {
+  margin: 0;
+}
+
+.gold-link {
+  color: var(--gold);
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.gold-link:hover {
+  text-decoration: underline;
+}
+
+/* Newsletter */
+.newsletter {
+  max-width: 500px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.newsletter h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+
+.newsletter p {
+  margin-top: 0;
+  font-size: 1rem;
+}
+
+.newsletter iframe {
+  width: 100% !important;
+  height: 180px;
+  border: none;
+  margin-top: 1rem;
+}
+
+/* Footer (legacy) */
+.footer {
+  background: var(--navy-blue);
+  color: var(--cream);
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.footer-content {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.footer p {
+  margin-bottom: 10px;
+}
+
+.footer .tagline {
+  color: var(--gold);
+  font-style: italic;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 {
+    font-size: 2.5rem;
+  }
+
+  .hero .tagline {
+    font-size: 1.1rem;
+  }
+
+  .apps-grid {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .section-header h2 {
+    font-size: 2rem;
+  }
+}
+
+/* Smooth scrolling */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Shared Utility Classes */
+.ulix-bg {
+  background: var(--ulix-bg);
+}
+
+.ulix-ink {
+  color: var(--ulix-ink);
+}
+
+.ulix-muted {
+  color: #b7c0d1;
+}
+
+.ulix-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.glow {
+  box-shadow: 0 8px 30px color-mix(in srgb, var(--gold), transparent 75%);
+}
+
+.video-wrap {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.video-wrap iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* Privacy Pages */
+.privacy-page {
+  padding: 2rem;
+  background-color: #ffffff;
+  color: var(--navy-blue);
+}
+
+.privacy-page main {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.privacy-page h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: var(--gold);
+}
+
+.privacy-page p {
+  margin-bottom: 1rem;
 }

--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -5,32 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
     <title>Guten Privacy Policy</title>
-    <style>
-      body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        line-height: 1.6;
-        background-color: #ffffff;
-        color: var(--navy-blue);
-      }
-      main {
-        max-width: 720px;
-        margin: 0 auto;
-      }
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 1rem;
-        color: var(--gold);
-      }
-      p {
-        margin-bottom: 1rem;
-      }
-    </style>
   </head>
-  <body>
+  <body class="privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Guten Privacy Policy</h1>

--- a/index.html
+++ b/index.html
@@ -6,222 +6,6 @@
     <title>Ulix - Precision Tools for Modern Odysseys</title>
     <link rel="icon" href="/favicon.png" type="image/png">
     <link rel="stylesheet" href="/assets/styles.css">
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Arial', sans-serif;
-            line-height: 1.6;
-        }
-
-        /* Colors from your logo */
-        :root {
-            --navy-blue: #1a2332;
-            --gold: #d4af37;
-            --cream: #f8f9fa;
-            --white: #ffffff;
-            --dark-text: #2c3e50;
-        }
-
-        /* Hero Section */
-        .hero {
-            background: #011530;
-            color: var(--cream);
-            padding: 20px 20px;
-            text-align: center;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-        }
-
-        .logo-container {
-            margin-bottom: 40px;
-        }
-
-        .main-logo {
-            width: 40vw;
-            max-width: 500px;
-            min-width: 300px;
-            height: auto;
-            margin: 0 auto 20px;
-        }
-
-        .hero h1 {
-            font-size: 3.5rem;
-            font-weight: bold;
-            color: var(--gold);
-            margin-bottom: 20px;
-            letter-spacing: 2px;
-        }
-
-        .hero .tagline {
-            font-size: 1.3rem;
-            margin-bottom: 30px;
-            color: var(--cream);
-            font-weight: 300;
-            letter-spacing: 1px;
-        }
-
-        .cta-button {
-            background: var(--gold);
-            color: var(--navy-blue);
-            padding: 15px 35px;
-            border: none;
-            border-radius: 30px;
-            font-size: 1.1rem;
-            font-weight: bold;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            text-decoration: none;
-            display: inline-block;
-        }
-
-        .cta-button:hover {
-            background: #e6c04a;
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(212, 175, 55, 0.3);
-        }
-
-        /* Apps Section */
-        .apps-section {
-            background: var(--cream);
-            padding: 80px 20px;
-        }
-
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-
-        .section-header {
-            text-align: center;
-            margin-bottom: 60px;
-        }
-
-        .section-header h2 {
-            font-size: 2.5rem;
-            color: var(--navy-blue);
-            margin-bottom: 15px;
-            font-weight: bold;
-        }
-
-        .section-header p {
-            font-size: 1.2rem;
-            color: var(--dark-text);
-        }
-
-        .apps-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-            gap: 30px;
-            margin-top: 50px;
-        }
-
-        .app-card {
-            background: var(--white);
-            padding: 30px;
-            border-radius: 15px;
-            text-align: center;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-            border: 2px solid transparent;
-        }
-
-        .app-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
-            border-color: var(--gold);
-        }
-
-        .app-icon {
-            width: 80px;
-            height: 80px;
-            border-radius: 15px;
-            margin: 0 auto 25px;
-            object-fit: cover;
-            display: block;
-        }
-
-        .status-badge {
-            display: block;
-            padding: 6px 16px;
-            border-radius: 20px;
-            font-size: 0.8rem;
-            font-weight: bold;
-            margin: 0 auto 15px;
-            width: fit-content;
-            white-space: nowrap;
-        }
-
-        .status-live {
-            background: #3498db;
-            color: white;
-        }
-
-        .status-development {
-            background: #2c3e50;
-            color: white;
-        }
-
-        .app-card h3 {
-            font-size: 1.5rem;
-            color: var(--navy-blue);
-            margin-bottom: 15px;
-            font-weight: bold;
-        }
-
-        /* Footer */
-        .footer {
-            background: var(--navy-blue);
-            color: var(--cream);
-            padding: 40px 20px;
-            text-align: center;
-        }
-
-        .footer-content {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-
-        .footer p {
-            margin-bottom: 10px;
-        }
-
-        .footer .tagline {
-            color: var(--gold);
-            font-style: italic;
-        }
-
-        /* Responsive */
-        @media (max-width: 768px) {
-            .hero h1 {
-                font-size: 2.5rem;
-            }
-
-            .hero .tagline {
-                font-size: 1.1rem;
-            }
-
-            .apps-grid {
-                grid-template-columns: 1fr;
-                gap: 20px;
-            }
-
-            .section-header h2 {
-                font-size: 2rem;
-            }
-        }
-
-        /* Smooth scrolling */
-        html {
-            scroll-behavior: smooth;
-        }
-    </style>
 </head>
 <body>
     <div data-include="/partials/header.html"></div>
@@ -231,7 +15,7 @@
             <img src="ulixh.png" alt="Ulix: Precision Tools for Modern Odysseys" class="main-logo">
             
         </div>
-        <a href="#apps" class="cta-button" style="display: none;">Explore Our Apps</a>
+        <a href="#apps" class="cta-button hidden">Explore Our Apps</a>
     </section>
 
     <!-- Apps Section -->
@@ -240,7 +24,7 @@
             <div class="section-header">
                 <h2>Our Applications</h2>
                 <p>Tools, not traps. Ulix builds digital tools for physical lives. No ads. No logins. No data-harvesting.</p>
-                <p style="font-size: 1rem; color: var(--dark-text); opacity: 0.7; margin-top: 10px;">
+                <p class="app-note">
                     Currently created for Android. iOS versions coming soon.
                 </p>
             </div>
@@ -251,8 +35,8 @@
                     
                     <div class="status-badge status-live">Live on Google Play</div>
                     <h3>Shelf Scan</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">Find books, games, and discs fast. Shelf Scan is Ctrl-F for the physical world.</p>
-                    <p style="margin: 0;"><a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener noreferrer" style="color: var(--gold); text-decoration: none; font-weight: bold;">See it on Google Play.</a></p>
+                    <p class="app-description">Find books, games, and discs fast. Shelf Scan is Ctrl-F for the physical world.</p>
+                    <p class="no-margin"><a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener noreferrer" class="gold-link">See it on Google Play.</a></p>
                 </div>
 
                 <div class="app-card">
@@ -260,8 +44,8 @@
                     
                     <div class="status-badge status-development">In Closed Testing on Google Play</div>
                     <h3>Loan It</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">Beautifully simple loan tracking. Effortlessly organize what you lend.</p>
-                    <p style="margin: 0;"><a href="https://play.google.com/store/apps/details?id=com.bhunt.loanit" target="_blank" rel="noopener noreferrer" style="color: var(--gold); text-decoration: none; font-weight: bold;">See it on Google Play.</a></p>
+                    <p class="app-description">Beautifully simple loan tracking. Effortlessly organize what you lend.</p>
+                    <p class="no-margin"><a href="https://play.google.com/store/apps/details?id=com.bhunt.loanit" target="_blank" rel="noopener noreferrer" class="gold-link">See it on Google Play.</a></p>
                 </div>
 
                 <div class="app-card">
@@ -269,8 +53,8 @@
                    
                     <div class="status-badge status-development">In Closed Testing on Google Play</div>
                     <h3>Track Analysis</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">Track food, sleep, symptoms, and more. Easily export data for analysis.</p>
-                    <p style="margin: 0;"><a href="https://play.google.com/store/apps/details?id=com.bhunt.trackanalysis" target="_blank" rel="noopener noreferrer" style="color: var(--gold); text-decoration: none; font-weight: bold;">See it on Google Play.</a></p>
+                    <p class="app-description">Track food, sleep, symptoms, and more. Easily export data for analysis.</p>
+                    <p class="no-margin"><a href="https://play.google.com/store/apps/details?id=com.bhunt.trackanalysis" target="_blank" rel="noopener noreferrer" class="gold-link">See it on Google Play.</a></p>
                 </div>
 
                 <div class="app-card">
@@ -278,7 +62,7 @@
                    
                     <div class="status-badge status-development">In Development</div>
                     <h3>Guten</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">A beautiful way to read the classics. Rediscover great books with smart features and timeless style.</p>
+                    <p class="app-description">A beautiful way to read the classics. Rediscover great books with smart features and timeless style.</p>
                     
                 </div>
 
@@ -287,7 +71,7 @@
                    
                     <div class="status-badge status-development">In Development</div>
                     <h3>Keep Clip</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">Capture, collect, and export text from almost any app on your phone. A modern commonplace book on your device.</p>
+                    <p class="app-description">Capture, collect, and export text from almost any app on your phone. A modern commonplace book on your device.</p>
                     
                 </div>
 
@@ -296,7 +80,7 @@
                    
                     <div class="status-badge status-development">In Development</div>
                     <h3>Shelf Sleuth</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">Made for library heroes. Find misshelved books with ease using your device camera.</p>
+                    <p class="app-description">Made for library heroes. Find misshelved books with ease using your device camera.</p>
                     
                 </div>
 
@@ -305,7 +89,7 @@
                     
                     <div class="status-badge status-development">In Development</div>
                     <h3>Curious Air</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;">Explore Bluetooth, Wi-Fi, and other ambient signals. Export logs. Find out what’s out there.</p>
+                    <p class="app-description">Explore Bluetooth, Wi-Fi, and other ambient signals. Export logs. Find out what’s out there.</p>
                     
                 </div>
 
@@ -314,25 +98,18 @@
                     
                     <div class="status-badge status-development">In Development</div>
                     <h3>Breaker of Horses</h3>
-                    <p style="color: var(--dark-text); margin: 15px 0; font-size: 1rem;"> A dedicated <i>Iliad</i> reader for immersive exploration.</p>
+                    <p class="app-description"> A dedicated <i>Iliad</i> reader for immersive exploration.</p>
                     
                 </div>
             </div>
         </div>
-        <div style="max-width: 500px; margin: 2rem auto; padding: 1rem;
-            background-color: #fff;
-            border: 1px solid #ccc; border-radius: 12px;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05); overflow: hidden;">
-  <h3 style="font-size: 1.25rem; margin-bottom: 0.5rem; margin-top: 0;">Signals from Ulix</h3>
-  <p style="margin-top: 0; font-size: 1rem;">
+        <div class="newsletter">
+  <h3>Signals from Ulix</h3>
+  <p>
     New apps, new updates, and the occasional interesting idea—for those who believe tools should serve.
   </p>
   <iframe
     scrolling="no"
-    style="width:100%!important;
-           height:180px;
-           border: none;
-           margin-top: 1rem;"
     src="https://buttondown.com/ulix?as_embed=true&theme=1677be"
   ></iframe>
 </div>

--- a/keepclipprivacypolicy.html
+++ b/keepclipprivacypolicy.html
@@ -5,32 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
     <title>Keep Clip Privacy Policy</title>
-    <style>
-      body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        line-height: 1.6;
-        background-color: #ffffff;
-        color: var(--navy-blue);
-      }
-      main {
-        max-width: 720px;
-        margin: 0 auto;
-      }
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 1rem;
-        color: var(--gold);
-      }
-      p {
-        margin-bottom: 1rem;
-      }
-    </style>
   </head>
-  <body>
+  <body class="privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Keep Clip Privacy Policy</h1>

--- a/shelfscan/index.html
+++ b/shelfscan/index.html
@@ -32,42 +32,6 @@
     />
     <meta name="twitter:image" content="https://ulix.app/favicon.png" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      :root {
-        --ulix-bg: #0b0d12;
-        --ulix-ink: #eaeef7;
-      }
-      .ulix-bg {
-        background: var(--ulix-bg);
-      }
-      .ulix-ink {
-        color: var(--ulix-ink);
-      }
-      .ulix-muted {
-        color: #b7c0d1;
-      }
-      .ulix-card {
-        background: rgba(255, 255, 255, 0.04);
-        border: 1px solid rgba(255, 255, 255, 0.08);
-      }
-      .glow {
-        box-shadow: 0 8px 30px color-mix(in srgb, var(--gold), transparent 75%);
-      }
-      /* Responsive 16:9 video embed without extra plugins */
-      .video-wrap {
-        position: relative;
-        width: 100%;
-        padding-top: 56.25%;
-        border-radius: 1rem;
-        overflow: hidden;
-      }
-      .video-wrap iframe {
-        position: absolute;
-        inset: 0;
-        width: 100%;
-        height: 100%;
-      }
-    </style>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/shelfscanprivacy.html
+++ b/shelfscanprivacy.html
@@ -5,32 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
     <title>Shelf Scan Privacy Policy</title>
-    <style>
-      body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        line-height: 1.6;
-        background-color: #ffffff;
-        color: var(--navy-blue);
-      }
-      main {
-        max-width: 720px;
-        margin: 0 auto;
-      }
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 1rem;
-        color: var(--gold);
-      }
-      p {
-        margin-bottom: 1rem;
-      }
-    </style>
   </head>
-  <body>
+  <body class="privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Shelf Scan Privacy Policy</h1>

--- a/trackanalysisprivacy.html
+++ b/trackanalysisprivacy.html
@@ -5,32 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
     <title>Track Analysis Privacy Policy</title>
-    <style>
-      body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        line-height: 1.6;
-        background-color: #ffffff;
-        color: var(--navy-blue);
-      }
-      main {
-        max-width: 720px;
-        margin: 0 auto;
-      }
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 1rem;
-        color: var(--gold);
-      }
-      p {
-        margin-bottom: 1rem;
-      }
-    </style>
   </head>
-  <body>
+  <body class="privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Track Analysis Privacy Policy</h1>


### PR DESCRIPTION
## Summary
- centralize layout, typography, and color variables in `assets/styles.css`
- remove inline styles from main and privacy pages
- link all pages to shared stylesheet for consistent branding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2498537c832f9e3b36c8233bd3d0