### PR TITLE
Display CTA button with focus styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -104,14 +104,13 @@ body {
   display: inline-block;
 }
 
-.cta-button:hover {
+.cta-button:hover,
+.cta-button:focus {
   background: #e6c04a;
   transform: translateY(-2px);
   box-shadow: 0 5px 15px rgba(212, 175, 55, 0.3);
-}
-
-.hidden {
-  display: none;
+  outline: 2px solid var(--navy-blue);
+  outline-offset: 2px;
 }
 
 /* Apps Section */

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
             <img src="ulixh.png" alt="Ulix: Precision Tools for Modern Odysseys" class="main-logo">
             
         </div>
-        <a href="#apps" class="cta-button hidden">Explore Our Apps</a>
+        <a href="#apps" class="cta-button">Explore Our Apps</a>
     </section>
 
     <!-- Apps Section -->


### PR DESCRIPTION
## Summary
- Reveal the hero section call-to-action button and link it to the apps section
- Style CTA with navy/gold palette and add hover/focus states for accessibility

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2b62d9c4832fb5424b8c36b79f8b