### PR TITLE
Apply shared layout and links for privacy policies

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -345,8 +345,8 @@ html {
 /* Privacy Pages */
 .privacy-page {
   padding: 2rem;
-  background-color: #ffffff;
-  color: var(--navy-blue);
+  background-color: var(--ulix-bg);
+  color: var(--ulix-ink);
 }
 
 .privacy-page main {

--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
+    <link rel="icon" href="/favicon.png" />
     <title>Guten Privacy Policy</title>
   </head>
-  <body class="privacy-page">
+  <body class="ulix-bg ulix-ink antialiased privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Guten Privacy Policy</h1>
@@ -46,6 +47,10 @@
       <p>
         Guten is designed to give you a distraction-free reading experience with
         complete control over your data.
+      </p>
+      <p>
+        <a href="/#apps" class="gold-link">Back to Guten</a> |
+        <a href="/" class="gold-link">Ulix Home</a>
       </p>
     </main>
     <div data-include="/partials/footer.html"></div>

--- a/keepclipprivacypolicy.html
+++ b/keepclipprivacypolicy.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
+    <link rel="icon" href="/favicon.png" />
     <title>Keep Clip Privacy Policy</title>
   </head>
-  <body class="privacy-page">
+  <body class="ulix-bg ulix-ink antialiased privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Keep Clip Privacy Policy</h1>
@@ -47,6 +48,10 @@
       <p>
         Keep Clip is designed to give you full control over your saved text,
         with minimal permissions and no external data sharing.
+      </p>
+      <p>
+        <a href="/#apps" class="gold-link">Back to Keep Clip</a> |
+        <a href="/" class="gold-link">Ulix Home</a>
       </p>
     </main>
     <div data-include="/partials/footer.html"></div>

--- a/shelfscanprivacy.html
+++ b/shelfscanprivacy.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
+    <link rel="icon" href="/favicon.png" />
     <title>Shelf Scan Privacy Policy</title>
   </head>
-  <body class="privacy-page">
+  <body class="ulix-bg ulix-ink antialiased privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Shelf Scan Privacy Policy</h1>
@@ -43,6 +44,10 @@
         Your data stays on your device unless you decide to share it. Shelf Scan
         is designed to work powerfully without ever needing an internet
         connection.
+      </p>
+      <p>
+        <a href="/shelfscan/" class="gold-link">Back to Shelf Scan</a> |
+        <a href="/" class="gold-link">Ulix Home</a>
       </p>
     </main>
     <div data-include="/partials/footer.html"></div>

--- a/trackanalysisprivacy.html
+++ b/trackanalysisprivacy.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
+    <link rel="icon" href="/favicon.png" />
     <title>Track Analysis Privacy Policy</title>
   </head>
-  <body class="privacy-page">
+  <body class="ulix-bg ulix-ink antialiased privacy-page">
     <div data-include="/partials/header.html"></div>
     <main>
       <h1>Track Analysis Privacy Policy</h1>
@@ -44,6 +45,17 @@
       <p>
         You remain in full control of your data. Nothing leaves your device
         unless you choose to export and share it.
+      </p>
+      <p>
+        <a
+          href="https://play.google.com/store/apps/details?id=com.ulix.trackanalysis"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="gold-link"
+          >Back to Track Analysis</a
+        >
+        |
+        <a href="/" class="gold-link">Ulix Home</a>
       </p>
     </main>
     <div data-include="/partials/footer.html"></div>


### PR DESCRIPTION
## Summary
- Wrap each app's privacy policy with shared header and footer.
- Apply site-wide color variables and styling to privacy policy pages.
- Add navigation links back to each app and home page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c9413f0832f921ae893edc8f413