### PR TITLE
Update app statuses for Track Analysis and Keep Clip

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@
 
                 <div class="app-card">
                     <img src="trackanalysis.png" alt="Track Analysis" class="app-icon">
-                   
-                    <div class="status-badge status-development">In Closed Testing on Google Play</div>
+
+                    <div class="status-badge status-live">Live on Google Play</div>
                     <h3>Track Analysis</h3>
                     <p class="app-description">Track food, sleep, symptoms, and more. Easily export data for analysis.</p>
                     <p class="no-margin"><a href="https://play.google.com/store/apps/details?id=com.ulix.trackanalysis" target="_blank" rel="noopener noreferrer" class="gold-link">See it on Google Play.</a></p>
@@ -79,11 +79,10 @@
 
                 <div class="app-card">
                     <img src="keepclip.png" alt="Keep Clip" class="app-icon">
-                   
-                    <div class="status-badge status-development">In Development</div>
+
+                    <div class="status-badge status-development">In Closed Testing on Google Play</div>
                     <h3>Keep Clip</h3>
                     <p class="app-description">Capture, collect, and export text from almost any app on your phone. A modern commonplace book on your device.</p>
-                    
                 </div>
 
                 <div class="app-card">


### PR DESCRIPTION
## Summary
- Mark Track Analysis as live on Google Play.
- Note Keep Clip is in closed testing on Google Play without linking to the store listing.

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_689e2c823e38832f8a09d2278042da3d