### PR TITLE
Copy shelfscan folder and simplify Android page CSS

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("assets");
+  eleventyConfig.addPassthroughCopy("shelfscan");
   eleventyConfig.addPassthroughCopy({"*.png": "."});
   eleventyConfig.addPassthroughCopy({"*.mp4": "."});
   eleventyConfig.addPassthroughCopy({"*.gif": "."});

--- a/shelfscan/android.html
+++ b/shelfscan/android.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/assets/styles.css" />
     <title>Shelf Scan — Find anything on your shelves in seconds</title>
     <meta
       name="description"


### PR DESCRIPTION
## Summary
- Copy `shelfscan` folder verbatim during Eleventy builds
- Remove global stylesheet reference from `shelfscan/android.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad4b037ec8832f917937437834dd32