### PR TITLE
fix: prevent split layout overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,11 +109,11 @@
 
     <!-- FIXED Split layout -->
     <section class="bg-[var(--ulix-primary)] text-white py-12">
-      <div class="mx-auto u-container px-4 sm:px-6">
+      <div class="mx-auto px-4 sm:px-6 max-w-full md:max-w-screen-xl">
         <div class="grid items-center gap-8 lg:grid-cols-2">
-          
+
           <!-- Left: tagline + CTAs -->
-          <div class="text-center lg:text-left">
+          <div class="max-w-full md:max-w-none mx-auto text-center lg:text-left">
             <h1 class="text-3xl md:text-4xl font-semibold tracking-tight">Tools, Not Traps</h1>
             <p class="mt-4 text-white/80">
               Apps designed to serve you, not sell you. Elegant and distraction-free, with no ads, no tracking, no attention hacking, and no intrusive permissions.
@@ -125,7 +125,7 @@
           </div>
 
           <!-- Right: carousel -->
-          <div class="w-full max-w-lg mx-auto lg:max-w-none">
+          <div class="mx-auto w-full max-w-full md:max-w-none">
             <div
               class="u-carousel relative overflow-hidden rounded-2xl border shadow w-full"
               style="border-color: rgba(255,255,255,.12); background: rgba(255,255,255,0.05)">


### PR DESCRIPTION
## Summary
- expand split layout to full width on mobile and screen-xl on desktop
- allow inner tagline and carousel wrappers to scale without overflow

## Testing
- `npx -y htmlhint index.html about.html terms.html`
- `npx -y -p puppeteer node <<'NODE' ... (module not found)`

------
https://chatgpt.com/codex/tasks/task_e_68b2440dde1c832fa43dbab9ab9e7003