### PR TITLE
Fix mobile overflow in split layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,12 +113,12 @@
         <div class="grid items-center gap-8 lg:grid-cols-2">
           
           <!-- Left: tagline + CTAs -->
-          <div class="text-center lg:text-left">
+          <div class="w-full max-w-full md:max-w-none mx-auto text-center lg:text-left">
             <h1 class="text-3xl md:text-4xl font-semibold tracking-tight">Tools, Not Traps</h1>
             <p class="mt-4 text-white/80">
               Apps designed to serve you, not sell you. Elegant and distraction-free, with no ads, no tracking, no attention hacking, and no intrusive permissions.
             </p>
-            <div class="mt-6 flex flex-col gap-3 sm:flex-row justify-center lg:justify-start">
+            <div class="mt-6 flex flex-col gap-3 sm:flex-row justify-center lg:justify-start w-full">
               <a href="./apps.html" class="u-btn u-btn-primary rounded-xl px-4 py-2 text-sm font-semibold">Explore Apps</a>
               <a href="./about.html" class="u-btn u-btn-secondary rounded-xl px-4 py-2 text-sm font-semibold">Why Ulix?</a>
             </div>


### PR DESCRIPTION
## Summary
- ensure split-layout tagline wrapper and buttons stretch full width on small screens to prevent overflow

## Testing
- `NODE_PATH=/tmp/puppeteer-test/node_modules node layout_test.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24ca65324832fa93f659933ff22f5