### PR TITLE
Fix mobile carousel spacing to prevent content cut-off

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
       max-width: 100%;
     }
     .u-carousel-track { display: flex; width: 100%; height: 100%; }
-    .u-carousel-slide { 
-      min-width: 100%; 
-      height: 100%; 
-      display: flex; 
-      align-items: center; 
-      box-sizing: border-box; 
+    .u-carousel-slide {
+      min-width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      box-sizing: border-box;
       padding: 0 0.75rem;
     }
     
@@ -40,10 +40,12 @@
       flex-wrap: nowrap;
     }
     
-    @media (max-width: 767px) { 
-      .u-carousel { height: 240px; } 
+    @media (max-width: 767px) {
+      .u-carousel { height: auto; }
+      .u-carousel-track { height: auto; }
       .u-carousel-slide {
-        padding: 0 0.5rem;
+        height: auto;
+        padding: 1rem 0.5rem;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- let the carousel and slides auto-size on mobile
- add vertical padding to mobile carousel slides to keep content visible

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2532f1fa8832f9908d7299014b0c6