### PR TITLE
fix: ensure hero split layout fits mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
       <div class="mx-auto u-container px-4 sm:px-6">
             <!-- NEW: mobile-narrow wrapper -->
     <div class="mx-auto w-full max-w-[40rem] md:max-w-none">
-        <div class="grid items-center gap-8 lg:grid-cols-2">
+        <div class="grid w-full grid-cols-1 items-center gap-8 lg:grid-cols-2">
           
           <!-- Left: tagline + CTAs -->
           <div class="text-center lg:text-left">


### PR DESCRIPTION
## Summary
- make hero split layout grid fill viewport on small screens

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2549bd5a4832f91ec7f3c1771ad58