### PR TITLE
Update Guten privacy policy text

### DIFF
--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -76,15 +76,35 @@
         <h1 class="text-3xl font-semibold" style="color: var(--ulix-primary)">Guten — Privacy Policy</h1>
         <div class="mt-6 grid gap-6">
           <div class="u-card rounded-2xl border bg-white p-5">
-            <p class="text-sm text-slate-700">Guten is a reading app that helps you explore public-domain books with full respect for your privacy. Here's how your data is handled:</p>
-            <ul class="mt-3 list-disc pl-5 text-sm text-slate-700 space-y-2">
-              <li>The app uses internet access only to fetch and download public-domain books and metadata from trusted sources such as the Gutendex API and Project Gutenberg.</li>
-              <li><strong>No personal information is collected, transmitted, or shared.</strong></li>
-              <li>Guten includes <strong>no analytics, advertising, or account-based services</strong>.</li>
-              <li>Downloaded books, bookmarks, reading progress, and similar records are stored <strong>locally</strong> on your device using private storage. This data never leaves your device unless you manually back it up or share it.</li>
-              <li>When opening or sharing external links (e.g., to Project Gutenberg), you may be directed to third-party websites. Their privacy policies apply independently of this app.</li>
+            <p class="text-sm text-slate-700">Guten Privacy Policy</p>
+            <p class="mt-3 text-sm text-slate-700">Guten is a reading app for public-domain books, designed to minimize data collection and keep your reading data under your control.</p>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">What Guten uses the internet for</h2>
+            <p class="mt-2 text-sm text-slate-700">Guten uses network access to fetch book listings, metadata, and downloadable book files from third-party public-domain sources, including Gutendex and Project Gutenberg.</p>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">What Guten does not do</h2>
+            <ul class="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-2">
+              <li>No user accounts</li>
+              <li>No in-app advertising</li>
+              <li>No third-party analytics or tracking SDKs</li>
             </ul>
-            <p class="mt-3 text-sm text-slate-700">Guten is designed to give you a distraction-free reading experience with complete control over your data.</p>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">Data stored on your device</h2>
+            <p class="mt-2 text-sm text-slate-700">Your downloaded books and reading data (such as bookmarks, highlights, notes, and reading progress) are stored locally on your device.</p>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">When data may leave your device</h2>
+            <p class="mt-2 text-sm text-slate-700">Data leaves your device only when you take an explicit action, such as:</p>
+            <ul class="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-2">
+              <li>opening external links,</li>
+              <li>sharing content through the system share menu, or</li>
+              <li>exporting/backing up your data.</li>
+            </ul>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">Third-party services</h2>
+            <p class="mt-2 text-sm text-slate-700">When Guten connects to external services (for example, Gutendex or Project Gutenberg), those services may receive standard technical request data (such as IP address and request headers) as part of normal internet communication. Their privacy policies apply to that processing.</p>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">External websites</h2>
+            <p class="mt-2 text-sm text-slate-700">If you open links to third-party websites, those sites operate under their own privacy policies, independent of Guten.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Replace the existing privacy-policy copy with the provided Guten Privacy Policy text to clearly describe network usage, data storage, and limits on data collection.
- Structure the policy into headings and lists so the information is easier to scan while keeping the current page layout and styling.

### Description
- Replaced the privacy content in `gutenprivacy.html` with the supplied policy, adding an intro and section headings for internet usage, prohibited behaviors, local data, data export, third-party services, and external websites.
- Converted the previous paragraph/list into multiple `h2` headings and `ul` lists and retained existing CSS classes and page structure for consistent presentation.
- Updated the single file `gutenprivacy.html` (net changes: 28 insertions, 8 deletions).

### Testing
- Served the site locally using `python3 -m http.server 4173` and verified the page responded successfully.
- Captured a full-page screenshot of `http://127.0.0.1:4173/gutenprivacy.html` using Playwright to visually validate the updated content, and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1395d08b4832f8e984f101b685fbe)