### PR TITLE
Add Premium features disclosure to Guten privacy policy

### DIFF
--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -103,6 +103,9 @@
             <h2 class="mt-5 text-base font-semibold text-slate-900">Third-party services</h2>
             <p class="mt-2 text-sm text-slate-700">When Guten connects to external services (for example, Gutendex or Project Gutenberg), those services may receive standard technical request data (such as IP address and request headers) as part of normal internet communication. Their privacy policies apply to that processing.</p>
 
+            <h2 class="mt-5 text-base font-semibold text-slate-900">Premium features</h2>
+            <p class="mt-2 text-sm text-slate-700">Guten offers optional premium features (such as text-to-speech, note export, and collections) available as a one-time in-app purchase. Purchases and purchase verification are handled entirely by Google Play Billing. Guten never sees your payment details. When you buy or restore a purchase, Google Play confirms your purchase status to the app; that confirmation is then stored locally on your device. Google's handling of your payment information and purchase history is governed by the Google Play privacy policy.</p>
+
             <h2 class="mt-5 text-base font-semibold text-slate-900">External websites</h2>
             <p class="mt-2 text-sm text-slate-700">If you open links to third-party websites, those sites operate under their own privacy policies, independent of Guten.</p>
           </div>


### PR DESCRIPTION
### Motivation
- Clarify how optional premium features are sold and how purchase data is handled so users understand that payments are processed by Google Play and Guten does not receive payment details.

### Description
- Inserted a new `Premium features` section into `gutenprivacy.html` (between `Third-party services` and `External websites`) describing one-time in-app purchases, Google Play Billing handling, local storage of purchase confirmation, and Google's privacy policy governance.

### Testing
- Started a local server with `python3 -m http.server 8000` and confirmed the page served successfully. 
- Inspected the updated file region with `nl -ba gutenprivacy.html | sed -n '95,170p'` to verify the new section is present. 
- Captured a full-page screenshot using a Playwright script to visually validate the change, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13c062314832fbbdf7cfb91a0c7ad)