### PR TITLE
Privacy: add Guten app policy, Sentry diagnostics section, and link from main privacy page

### DIFF
--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -74,6 +74,7 @@
     <section class="py-14" style="background: var(--ulix-bg)">
       <div class="mx-auto u-container px-4 sm:px-6">
         <h1 class="text-3xl font-semibold" style="color: var(--ulix-primary)">Guten — Privacy Policy</h1>
+        <p class="mt-2 text-sm text-slate-600">Last updated: April 7, 2026</p>
         <div class="mt-6 grid gap-6">
           <div class="u-card rounded-2xl border bg-white p-5">
           
@@ -84,10 +85,16 @@
 
             <h2 class="mt-5 text-base font-semibold text-slate-900">What Guten does not do</h2>
             <ul class="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-2">
-              <li>No user accounts</li>
-              <li>No in-app advertising</li>
-              <li>No third-party analytics or tracking SDKs</li>
+              <li>No ads</li>
+              <li>No sale of personal data</li>
+              <li>No account required to read books</li>
             </ul>
+
+            <h2 class="mt-5 text-base font-semibold text-slate-900">Crash and reliability diagnostics (Sentry)</h2>
+            <p class="mt-2 text-sm text-slate-700">Guten uses Sentry only to help detect, investigate, and fix crashes or other stability issues so the app stays reliable.</p>
+            <p class="mt-2 text-sm text-slate-700">Diagnostics typically include technical details such as app version, operating system version, device model, stack traces, and event timestamps.</p>
+            <p class="mt-2 text-sm text-slate-700">Guten’s crash diagnostics are configured to exclude your book library contents and highlights/notes text.</p>
+            <p class="mt-2 text-sm text-slate-700">As part of standard internet request handling, Sentry may process technical identifiers such as IP address. See the <a class="underline" href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer">Sentry Privacy Policy</a> for more detail.</p>
 
             <h2 class="mt-5 text-base font-semibold text-slate-900">Data stored on your device</h2>
             <p class="mt-2 text-sm text-slate-700">Your downloaded books and reading data (such as bookmarks, highlights, notes, and reading progress) are stored locally on your device.</p>
@@ -100,8 +107,11 @@
               <li>exporting/backing up your data.</li>
             </ul>
 
+            <h2 class="mt-5 text-base font-semibold text-slate-900">Your controls</h2>
+            <p class="mt-2 text-sm text-slate-700">Guten does not use diagnostics for advertising, cross-app profiling, or behavioral marketing. Diagnostic data is limited to reliability and crash troubleshooting.</p>
+
             <h2 class="mt-5 text-base font-semibold text-slate-900">Third-party services</h2>
-            <p class="mt-2 text-sm text-slate-700">When Guten connects to external services (for example, Gutendex or Project Gutenberg), those services may receive standard technical request data (such as IP address and request headers) as part of normal internet communication. Their privacy policies apply to that processing.</p>
+            <p class="mt-2 text-sm text-slate-700">Guten uses the following third-party services: Gutendex and Project Gutenberg (for catalog and book content), Sentry (for crash and reliability diagnostics), and Google Play Billing (for optional premium purchases). These services may receive standard technical request data (such as IP address and request headers) as part of normal internet communication. Their privacy policies apply to that processing.</p>
 
             <h2 class="mt-5 text-base font-semibold text-slate-900">Premium features</h2>
             <p class="mt-2 text-sm text-slate-700">Guten offers optional premium features (such as text-to-speech, note export, and collections) available as a one-time in-app purchase. Purchases and purchase verification are handled entirely by Google Play Billing. Guten never sees your payment details. When you buy or restore a purchase, Google Play confirms your purchase status to the app; that confirmation is then stored locally on your device. Google's handling of your payment information and purchase history is governed by the Google Play privacy policy.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -76,7 +76,8 @@
       <div class="mx-auto u-container px-4 sm:px-6">
         <h1 class="text-4xl md:text-5xl font-semibold tracking-tight">Privacy at Ulix</h1>
         <p class="mt-3 text-white/80 max-w-2xl mx-auto">
-          Ulix is privacy-first. We don’t run ads, require accounts, or sell your data.  
+          Ulix is privacy-first. We don’t run ads or sell personal data, and many apps do not require an account.
+          Some apps may use limited third-party services for core functionality or reliability diagnostics as described in each app-specific policy.
           For details, see the app-specific policies below.
         </p>
       </div>
@@ -88,6 +89,7 @@
         <div class="u-card rounded-2xl border bg-white p-6">
           <h2 class="text-xl font-semibold" style="color: var(--ulix-primary)">App-Specific Privacy Policies</h2>
           <ul class="mt-3 list-disc pl-5 text-sm text-slate-700">
+            <li><a class="underline" href="./gutenprivacy.html">Guten Privacy Policy</a></li>
             <li><a class="underline" href="./shelfscanprivacy.html">Shelf Scan Privacy Policy</a></li>
             <li><a class="underline" href="./keepclipprivacypolicy.html">Keep Clip Privacy Policy</a></li>
             <li><a class="underline" href="./trackanalysisprivacy.html">Track Analysis Privacy Policy</a></li>


### PR DESCRIPTION
### Motivation
- Clarify app-specific privacy details for Guten, including diagnostic usage and limits. 
- Improve transparency by adding a "Last updated" date and listing third-party services used. 
- Surface the Guten policy from the main Ulix privacy page so users can access app-specific details.

### Description
- Added a "Last updated: April 7, 2026" line and expanded the Guten privacy text in `gutenprivacy.html` to better describe storage, when data leaves the device, and user controls. 
- Introduced a new "Crash and reliability diagnostics (Sentry)" section that explains what diagnostic data may be collected and states exclusions for library/notes. 
- Reworked the "What Guten does not do" list and updated the "Third-party services" paragraph to include Sentry and Google Play Billing, and clarified external data handling. 
- Updated the main privacy page (`privacy.html`) hero copy for nuance about accounts/third-party services and added a link to the new Guten policy in the app-specific list.

### Testing
- Performed a local static site build with `npm run build` which completed without errors. 
- No automated unit tests apply to these static HTML content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d549742ba0832fa493184c6106935b)