### PR TITLE
Refine split tagline and carousel responsive styles

### DIFF
--- a/assets/ulix.css
+++ b/assets/ulix.css
@@ -413,6 +413,7 @@ button { font: inherit; cursor: pointer; }
   .split__text { text-align: left; }
   .split__ctas { justify-content: flex-start; }
 }
+@media (min-width: 1024px) { .split__tagline { font-size: 2.75rem; } }
 
 .carousel {
   position: relative;
@@ -425,7 +426,7 @@ button { font: inherit; cursor: pointer; }
   box-shadow: var(--shadow-btn);
   overflow: hidden;
 }
-@media (min-width: 768px) { .carousel { max-width: 100%; } }
+@media (min-width: 768px) { .carousel { max-width: 36rem; } }
 
 .carousel__viewport { overflow: hidden; }
 .carousel__track {
@@ -495,7 +496,7 @@ button { font: inherit; cursor: pointer; }
   font-weight: 600;
 }
 @media (min-width: 1024px) {
-  .carousel__inner { grid-template-columns: 2fr 3fr; text-align: left; align-items: center; }
+  .carousel__inner { grid-template-columns: auto 1fr; column-gap: 1.25rem; text-align: left; align-items: center; }
   .carousel__icon { margin: 0; }
   .carousel__ctas { justify-content: flex-start; }
 }


### PR DESCRIPTION
## Summary
Updated responsive design styles for the split section tagline and carousel component to improve layout consistency and visual hierarchy across different screen sizes.

## Key Changes
- Added media query for split tagline font sizing at 1024px breakpoint (2.75rem)
- Adjusted carousel max-width from 100% to 36rem at 768px breakpoint for better content containment
- Refined carousel inner grid layout at 1024px:
  - Changed grid columns from `2fr 3fr` to `auto 1fr` for more flexible content sizing
  - Added explicit column gap of 1.25rem for consistent spacing
  - Maintained text alignment and vertical centering

## Implementation Details
These changes improve the responsive behavior of key components by:
- Ensuring the split tagline scales appropriately on larger screens
- Constraining carousel width to prevent excessive stretching on tablets
- Using flexible grid sizing (`auto 1fr`) instead of fixed fractions for better content-driven layout on desktop

https://claude.ai/code/session_01JJ1nf1BojiWEBrskmUD3ju