### PR TITLE
Fix text overflow in grid and carousel layouts

### DIFF
--- a/assets/ulix.css
+++ b/assets/ulix.css
@@ -388,6 +388,7 @@ button { font: inherit; cursor: pointer; }
   max-width: 40rem;
   margin: 0 auto;
 }
+.split__grid > * { min-width: 0; }
 .split__text { text-align: center; }
 .split__tagline {
   color: #fff;
@@ -419,6 +420,7 @@ button { font: inherit; cursor: pointer; }
   position: relative;
   width: 100%;
   max-width: 32rem;
+  min-width: 0;
   margin: 0 auto;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.05);
@@ -436,6 +438,7 @@ button { font: inherit; cursor: pointer; }
 }
 .carousel__slide {
   flex: 0 0 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
   padding: 0 0.75rem;


### PR DESCRIPTION
## Summary
Added `min-width: 0` CSS properties to prevent text overflow issues in flex containers, ensuring proper text truncation and wrapping behavior.

## Key Changes
- Added `min-width: 0` to `.split__grid > *` to allow grid children to shrink below their content size
- Added `min-width: 0` to `.split__form` to prevent form overflow in flex layouts
- Added `min-width: 0` to `.carousel__slide` to enable proper text handling in carousel slides

## Implementation Details
These changes address a common flexbox issue where flex items don't shrink below their content width by default. By explicitly setting `min-width: 0`, we allow flex children to respect overflow properties and text truncation rules, preventing layout breakage when content exceeds available space.

https://claude.ai/code/session_01VDEZhB9NnPYZ6VJ5ARBkqT