### PR TITLE
Add Guten landing page with comprehensive product showcase

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -129,8 +129,7 @@
               Read thousands of classic books from Project Gutenberg in a clean, distraction-free reader.
               Gutenberg is currently in testing on Google Play.
             </p>
-            <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener"
-               class="btn btn--primary app-card__cta">Join testing on Google Play</a>
+            <a href="./guten/" class="btn btn--primary app-card__cta">Learn more</a>
           </article>
 
           <article class="card app-card">

--- a/guten/index.html
+++ b/guten/index.html
@@ -1,0 +1,1131 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Guten — Read more. Scroll less.</title>
+  <meta name="description" content="70,000+ free public-domain classics in a quiet, focused EPUB reader. No account. No ads. Just books." />
+  <link rel="canonical" href="https://ulix.app/guten/" />
+  <meta name="theme-color" content="#0F0E0C" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Ulix" />
+  <meta property="og:title" content="Guten — Read more. Scroll less." />
+  <meta property="og:description" content="70,000+ free public-domain classics in a quiet, focused EPUB reader. No account. No ads. Just books." />
+  <meta property="og:url" content="https://ulix.app/guten/" />
+  <meta property="og:image" content="https://ulix.app/icons/guten.png" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Guten — Read more. Scroll less." />
+  <meta name="twitter:description" content="70,000+ free public-domain classics in a quiet, focused EPUB reader." />
+  <meta name="twitter:image" content="https://ulix.app/icons/guten.png" />
+
+  <link rel="icon" href="../icons/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="../icons/favicon.png" />
+  <link rel="stylesheet" href="../assets/ulix.css" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Guten",
+    "operatingSystem": "Android",
+    "applicationCategory": "http://schema.org/BookApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ulix.app/guten/",
+    "downloadUrl": "https://play.google.com/store/apps/details?id=com.bhunt.guten",
+    "publisher": { "@type": "Organization", "name": "Ulix LLC" },
+    "description": "70,000+ free public-domain classics in a quiet, focused EPUB reader. No account. No ads."
+  }
+  </script>
+
+  <style>
+  /* ==========================================================================
+     Guten landing page — scoped to .guten-page
+     Loaded after ulix.css so these rules win on specificity within the wrapper.
+     ========================================================================== */
+
+  .guten-page {
+    --bg: #0F0E0C;
+    --fg: #F4EFE6;
+    --muted: rgba(244,239,230,0.65);
+    --subtle: rgba(244,239,230,0.45);
+    --card-bg: #181614;
+    --rule: rgba(244,239,230,0.12);
+    --nav-rule: rgba(244,239,230,0.1);
+    --accent: #E5B83A;
+    --serif: 'Newsreader', Georgia, serif;
+    --sans: Geist, system-ui, sans-serif;
+
+    /* Override site tokens so site-header / site-footer / drawer pick up
+       the warm-dark palette inside this page only. */
+    --ulix-primary: #0F0E0C;
+    --ulix-primary-dark: #0F0E0C;
+    --ulix-accent: #E5B83A;
+    --ulix-bg: #0F0E0C;
+    --ulix-ink: #F4EFE6;
+
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Site chrome tweaks for warm-dark palette */
+  .guten-page .site-header { border-bottom-color: rgba(244,239,230,0.1); }
+  .guten-page .btn--primary { background: var(--accent); color: #0F0E0C; }
+  .guten-page .site-footer { border-top-color: rgba(244,239,230,0.12); color: rgba(244,239,230,0.7); }
+  .guten-page .site-footer__tag,
+  .guten-page .site-footer__copyright,
+  .guten-page .site-footer__links a { color: rgba(244,239,230,0.7); }
+  .guten-page .site-footer__brand-name,
+  .guten-page .site-footer__links a:hover { color: var(--fg); }
+
+  .guten-page a { color: inherit; text-decoration: none; }
+  .guten-page img { display: block; user-select: none; -webkit-user-drag: none; }
+  .guten-page h1, .guten-page h2, .guten-page h3 { margin: 0; color: var(--fg); }
+  .guten-page p, .guten-page ul, .guten-page figure { margin: 0; }
+  .guten-page ul { list-style: none; padding: 0; }
+
+  .guten-page .page { max-width: 1280px; margin: 0 auto; }
+
+  /* ---------- Phone frame ---------- */
+  .guten-page .phone {
+    width: calc(280px * var(--s, 1));
+    height: calc(580px * var(--s, 1));
+    border-radius: calc(38px * var(--s, 1));
+    padding: calc(8px * var(--s, 1));
+    background: linear-gradient(180deg, #1a1a1a 0%, #050505 100%);
+    box-shadow:
+      0 calc(30px * var(--s, 1)) calc(80px * var(--s, 1)) rgba(0,0,0,0.35),
+      0 calc(4px * var(--s, 1)) calc(12px * var(--s, 1)) rgba(0,0,0,0.18),
+      inset 0 0 0 1px rgba(255,255,255,0.06);
+    transform: rotate(var(--r, 0deg));
+    flex-shrink: 0;
+    position: relative;
+  }
+  .guten-page .phone-screen {
+    width: 100%;
+    height: 100%;
+    border-radius: calc(30px * var(--s, 1));
+    overflow: hidden;
+    background: #000;
+  }
+  .guten-page .phone-screen img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: top;
+  }
+
+  /* ---------- Eyebrow ---------- */
+  .guten-page .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-family: var(--sans);
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(244,239,230,0.6);
+    font-weight: 500;
+  }
+  .guten-page .eyebrow::before {
+    content: "";
+    display: block;
+    width: 24px;
+    height: 1px;
+    background: var(--accent);
+    opacity: 0.8;
+    flex-shrink: 0;
+  }
+
+  /* ---------- Section divider ---------- */
+  .guten-page .divider {
+    height: 1px;
+    background: var(--rule);
+    margin: 0 80px;
+  }
+
+  /* ---------- Play badge ---------- */
+  .guten-page .play-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: #0F0E0C;
+    color: var(--fg);
+    padding: 14px 22px;
+    border-radius: 999px;
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    border: 1px solid #2a2724;
+    box-shadow: 0 1px 0 rgba(255,255,255,0.04) inset;
+    transition: transform 0.15s;
+  }
+  .guten-page .play-badge:hover { transform: translateY(-1px); }
+  .guten-page .play-badge--lg { padding: 15.4px 24.2px; gap: 13.2px; font-size: 16.5px; }
+  .guten-page .play-badge__text { display: flex; flex-direction: column; line-height: 1.1; text-align: left; }
+  .guten-page .play-badge__sub { font-size: 10px; opacity: 0.65; letter-spacing: 0.08em; text-transform: uppercase; }
+  .guten-page .play-badge__main { font-size: 17px; font-weight: 600; letter-spacing: -0.02em; }
+  .guten-page .play-badge--lg .play-badge__sub { font-size: 11px; }
+  .guten-page .play-badge--lg .play-badge__main { font-size: 18.7px; }
+
+  /* ---------- Secondary link ---------- */
+  .guten-page .secondary-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: rgba(244,239,230,0.7);
+    font-family: var(--sans);
+    font-size: 14px;
+    font-weight: 500;
+    padding: 12px 4px;
+    border-bottom: 1px solid rgba(244,239,230,0.25);
+  }
+
+  /* ---------- Hero ---------- */
+  .guten-page .g-hero {
+    padding: 48px 80px 100px;
+    position: relative;
+    overflow: hidden;
+    min-height: 800px;
+  }
+  .guten-page .g-hero__grid {
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
+    gap: 60px;
+    align-items: center;
+    margin-top: 28px;
+  }
+  .guten-page .g-hero__title {
+    font-family: var(--serif);
+    font-size: 115px;
+    font-weight: 300;
+    line-height: 0.96;
+    letter-spacing: -0.025em;
+    text-wrap: balance;
+    color: var(--fg);
+  }
+  .guten-page .g-hero__title em {
+    font-style: italic;
+    color: var(--accent);
+    font-weight: 300;
+  }
+  .guten-page .g-hero__lede {
+    font-family: var(--serif);
+    font-size: 22px;
+    line-height: 1.45;
+    color: var(--muted);
+    margin-top: 28px;
+    max-width: 480px;
+    font-weight: 300;
+  }
+  .guten-page .g-hero__ctas {
+    margin-top: 36px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+  .guten-page .g-hero__stats {
+    margin-top: 40px;
+    display: flex;
+    align-items: stretch;
+    gap: 28px;
+    font-size: 13px;
+    color: var(--muted);
+  }
+  .guten-page .stat__value {
+    font-family: var(--serif);
+    font-size: 26px;
+    color: var(--accent);
+    font-weight: 400;
+    line-height: 1;
+  }
+  .guten-page .stat__label {
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-top: 6px;
+    opacity: 0.7;
+  }
+  .guten-page .stat__sep { width: 1px; background: var(--rule); align-self: stretch; }
+  .guten-page .g-hero__art {
+    position: relative;
+    height: 720px;
+  }
+  .guten-page .g-hero__glow {
+    position: absolute;
+    inset: 0;
+    top: 40px;
+    background: radial-gradient(50% 50% at 50% 40%, #E5B83A30, transparent 70%);
+    filter: blur(40px);
+    pointer-events: none;
+  }
+  .guten-page .g-hero__phone-1 { position: absolute; left: -20px; top: 80px; z-index: 1; }
+  .guten-page .g-hero__phone-2 { position: absolute; right: 0; top: 0; z-index: 2; }
+
+  /* ---------- Catalog section ---------- */
+  .guten-page .catalog {
+    padding: 64px 80px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    align-items: center;
+  }
+  .guten-page .catalog__art {
+    position: relative;
+    height: 460px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .guten-page .catalog__glow {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(50% 50% at 50% 50%, #E5B83A22, transparent 70%);
+    filter: blur(40px);
+    pointer-events: none;
+  }
+  .guten-page .catalog__phone-1 { position: relative; left: 40px; z-index: 1; }
+  .guten-page .catalog__phone-2 { position: relative; left: -40px; z-index: 2; }
+  .guten-page .catalog__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 62px;
+    letter-spacing: -0.025em;
+    margin: 0 0 20px;
+    line-height: 1.0;
+    text-wrap: balance;
+    max-width: 550px;
+    color: var(--fg);
+  }
+  .guten-page .catalog__title em { color: var(--accent); }
+  .guten-page .catalog__body {
+    font-family: var(--serif);
+    font-size: 17px;
+    line-height: 1.55;
+    color: var(--muted);
+    max-width: 460px;
+    font-weight: 300;
+  }
+  .guten-page .catalog__chips {
+    margin-top: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .guten-page .author-chip {
+    padding: 5px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--rule);
+    font-size: 12px;
+    color: var(--muted);
+    font-family: var(--serif);
+    font-style: italic;
+  }
+
+  /* ---------- Features section ---------- */
+  .guten-page .features { padding: 100px 80px; }
+  .guten-page .features__header {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    align-items: end;
+    margin-bottom: 72px;
+  }
+  .guten-page .features__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 56px;
+    letter-spacing: -0.02em;
+    margin: 20px 0 0;
+    max-width: 560px;
+    line-height: 1.05;
+    text-wrap: balance;
+    color: var(--fg);
+  }
+  .guten-page .features__title em { color: var(--accent); }
+  .guten-page .features__support {
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--muted);
+    max-width: 420px;
+    justify-self: end;
+  }
+  .guten-page .features__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 32px;
+  }
+  .guten-page .feature {
+    border-top: 1px solid var(--rule);
+    padding-top: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+  .guten-page .feature__num {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 13px;
+    color: var(--accent);
+    letter-spacing: 0.04em;
+  }
+  .guten-page .feature__art {
+    background: var(--card-bg);
+    border-radius: 8px;
+    height: 320px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding-top: 32px;
+    overflow: hidden;
+  }
+  .guten-page .feature__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 26px;
+    letter-spacing: -0.015em;
+    color: var(--fg);
+  }
+  .guten-page .feature__body {
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--muted);
+    margin-top: 12px;
+  }
+
+  /* ---------- Themes section ---------- */
+  .guten-page .themes { padding: 100px 80px; }
+  .guten-page .themes__header {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto 60px;
+  }
+  .guten-page .themes__eyebrow {
+    font-family: var(--serif);
+    font-size: 18px;
+    color: var(--accent);
+    font-style: italic;
+    letter-spacing: 0.1em;
+  }
+  .guten-page .themes__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 64px;
+    letter-spacing: -0.025em;
+    margin: 20px 0 24px;
+    line-height: 1.0;
+    color: var(--fg);
+  }
+  .guten-page .themes__title em { color: var(--accent); }
+  .guten-page .themes__body {
+    font-family: var(--serif);
+    font-size: 18px;
+    line-height: 1.65;
+    color: var(--muted);
+    font-weight: 300;
+  }
+  .guten-page .themes__row {
+    display: flex;
+    gap: 60px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .guten-page .theme { text-align: center; }
+  .guten-page .theme__caption {
+    margin-top: 24px;
+    font-size: 11px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--subtle);
+  }
+  .guten-page .theme__num { color: var(--accent); margin-right: 10px; }
+
+  /* ---------- Habits section ---------- */
+  .guten-page .habits {
+    padding: 100px 80px;
+    display: grid;
+    grid-template-columns: 0.85fr 1.15fr;
+    gap: 80px;
+    align-items: center;
+  }
+  .guten-page .habits__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 56px;
+    letter-spacing: -0.02em;
+    margin: 20px 0 24px;
+    line-height: 1.05;
+    color: var(--fg);
+  }
+  .guten-page .habits__body {
+    font-size: 17px;
+    line-height: 1.55;
+    color: var(--muted);
+    max-width: 440px;
+  }
+  .guten-page .habits__list {
+    margin-top: 32px;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--fg);
+  }
+  .guten-page .habits__list li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .guten-page .habits__list li::before {
+    content: "";
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--accent);
+    flex-shrink: 0;
+  }
+  .guten-page .habits__art {
+    background: var(--card-bg);
+    border-radius: 32px;
+    padding: 60px 60px 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    min-height: 560px;
+    position: relative;
+    overflow: hidden;
+  }
+  .guten-page .habits__quote {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    font-family: var(--serif);
+    font-size: 14px;
+    color: var(--muted);
+    font-style: italic;
+  }
+
+  /* ---------- Premium section ---------- */
+  .guten-page .premium { padding: 100px 80px; }
+  .guten-page .premium__header {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 24px;
+  }
+  .guten-page .premium__eyebrow {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 18px;
+    letter-spacing: 0.1em;
+    color: var(--accent);
+  }
+  .guten-page .premium__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 64px;
+    letter-spacing: -0.025em;
+    margin: 20px 0 24px;
+    line-height: 1.0;
+    text-wrap: balance;
+    color: var(--fg);
+  }
+  .guten-page .premium__title em { color: var(--accent); }
+  .guten-page .premium__body {
+    font-family: var(--serif);
+    font-size: 18px;
+    line-height: 1.65;
+    color: var(--muted);
+    font-weight: 300;
+  }
+  .guten-page .premium__pill-wrap { text-align: center; margin: 28px 0 60px; }
+  .guten-page .premium__pill {
+    display: inline-flex;
+    gap: 10px;
+    align-items: center;
+    padding: 8px 18px;
+    border-radius: 999px;
+    border: 1px solid var(--rule);
+    font-size: 13px;
+    color: var(--muted);
+    letter-spacing: 0.04em;
+  }
+  .guten-page .premium__pill::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    flex-shrink: 0;
+  }
+  .guten-page .premium__grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 32px;
+  }
+  .guten-page .premium-card {
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .guten-page .premium-card__num {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 13px;
+    color: var(--accent);
+    letter-spacing: 0.04em;
+  }
+  .guten-page .premium-card__art {
+    background: var(--card-bg);
+    border-radius: 6px;
+    height: 320px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding-top: 28px;
+    overflow: hidden;
+  }
+  .guten-page .premium-card__shelves {
+    background: var(--card-bg);
+    border-radius: 6px;
+    min-height: 300px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 36px;
+    text-align: center;
+  }
+  .guten-page .shelves-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+    max-width: 280px;
+  }
+  .guten-page .shelf-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 18px;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    font-family: var(--serif);
+    font-size: 16px;
+    color: var(--fg);
+  }
+  .guten-page .shelf-row__num { color: var(--accent); margin-right: 10px; font-style: italic; }
+  .guten-page .shelf-row__count { font-size: 12px; color: var(--muted); }
+  .guten-page .premium-card__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 24px;
+    letter-spacing: -0.015em;
+    color: var(--fg);
+  }
+  .guten-page .premium-card__body {
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--muted);
+    margin-top: 10px;
+  }
+
+  /* ---------- Bottom CTA ---------- */
+  .guten-page .g-cta {
+    padding: 120px 80px;
+    text-align: center;
+  }
+  .guten-page .g-cta__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 96px;
+    letter-spacing: -0.025em;
+    line-height: 0.98;
+    text-wrap: balance;
+    color: var(--fg);
+  }
+  .guten-page .g-cta__title em { color: var(--accent); }
+  .guten-page .g-cta__body {
+    font-size: 19px;
+    color: var(--muted);
+    margin: 28px auto 0;
+    max-width: 540px;
+    line-height: 1.5;
+  }
+  .guten-page .g-cta__action {
+    margin-top: 40px;
+    display: flex;
+    justify-content: center;
+  }
+
+  /* ---------- Cheap responsive pass ---------- */
+  @media (max-width: 900px) {
+    .guten-page .divider { margin: 0 24px; }
+    .guten-page .g-hero { padding: 32px 24px 60px; min-height: 0; }
+    .guten-page .g-hero__grid { grid-template-columns: 1fr; gap: 40px; }
+    .guten-page .g-hero__title { font-size: 56px; }
+    .guten-page .g-hero__lede { font-size: 18px; }
+    .guten-page .g-hero__art { height: 480px; }
+    .guten-page .g-hero__phone-1 { left: 0; top: 40px; }
+    .guten-page .g-hero__phone-2 { right: 0; top: 0; }
+    .guten-page .g-hero__stats { flex-wrap: wrap; gap: 16px 20px; }
+    .guten-page .stat__sep { display: none; }
+
+    .guten-page .catalog { padding: 48px 24px; grid-template-columns: 1fr; gap: 40px; }
+    .guten-page .catalog__art { height: 380px; }
+    .guten-page .catalog__title { font-size: 40px; }
+
+    .guten-page .features { padding: 60px 24px; }
+    .guten-page .features__header { grid-template-columns: 1fr; gap: 24px; margin-bottom: 40px; }
+    .guten-page .features__title { font-size: 36px; }
+    .guten-page .features__support { justify-self: start; }
+    .guten-page .features__grid { grid-template-columns: 1fr; gap: 28px; }
+    .guten-page .feature__art { height: 260px; }
+
+    .guten-page .themes { padding: 60px 24px; }
+    .guten-page .themes__title { font-size: 40px; }
+    .guten-page .themes__row { gap: 32px; }
+
+    .guten-page .habits { padding: 60px 24px; grid-template-columns: 1fr; gap: 40px; }
+    .guten-page .habits__title { font-size: 36px; }
+    .guten-page .habits__art { padding: 40px 24px 0; min-height: 480px; border-radius: 20px; }
+    .guten-page .habits__quote { top: 24px; left: 24px; }
+
+    .guten-page .premium { padding: 60px 24px; }
+    .guten-page .premium__title { font-size: 40px; }
+    .guten-page .premium__grid { grid-template-columns: 1fr; gap: 20px; }
+    .guten-page .premium-card__art { height: 260px; }
+
+    .guten-page .g-cta { padding: 72px 24px; }
+    .guten-page .g-cta__title { font-size: 48px; }
+    .guten-page .g-cta__body { font-size: 16px; }
+  }
+  </style>
+</head>
+
+<body class="guten-page">
+  <a href="#main" class="skip-link">Skip to content</a>
+
+  <header class="site-header">
+    <div class="container container--wide site-header__inner">
+      <a href="../index.html" class="site-brand">
+        <img src="../icons/favicon.png" alt="" class="site-brand__logo" />
+        <span class="site-brand__name">ULIX</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="../index.html" class="site-nav__link">Home</a>
+        <a href="../apps.html" class="site-nav__link" aria-current="page">Apps</a>
+        <a href="../blog.html" class="site-nav__link">Blog</a>
+        <a href="../about.html" class="site-nav__link">About</a>
+        <a href="../contact.html" class="site-nav__link">Contact</a>
+      </nav>
+      <div class="site-header__actions">
+        <button id="u-menu-btn" class="menu-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="u-mobile">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="4" y1="7"  x2="20" y2="7"/>
+            <line x1="4" y1="12" x2="20" y2="12"/>
+            <line x1="4" y1="17" x2="20" y2="17"/>
+          </svg>
+        </button>
+        <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener" class="btn btn--primary btn--header">Get Guten</a>
+      </div>
+    </div>
+  </header>
+
+  <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
+    <div class="drawer__backdrop" data-close></div>
+    <div class="drawer__panel">
+      <div class="drawer__header">
+        <span class="drawer__title">Menu</span>
+        <button class="drawer__close" aria-label="Close menu" data-close>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </button>
+      </div>
+      <ul class="drawer__list">
+        <li><a class="drawer__link" href="../index.html" data-close>Home</a></li>
+        <li><a class="drawer__link" href="../apps.html" data-close>Apps</a></li>
+        <li><a class="drawer__link" href="../blog.html" data-close>Blog</a></li>
+        <li><a class="drawer__link" href="../about.html" data-close>About</a></li>
+        <li><a class="drawer__link" href="../contact.html" data-close>Contact</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <main id="main">
+    <div class="page">
+
+      <!-- ============ HERO ============ -->
+      <section class="g-hero">
+        <span class="eyebrow">Ulix · Reading</span>
+        <div class="g-hero__grid">
+          <div>
+            <h1 class="g-hero__title">
+              Read more.<br>
+              <em>Scroll less.</em>
+            </h1>
+            <p class="g-hero__lede">
+              Guten gives you 70,000+ free, public-domain classics from Project Gutenberg in a quiet, focused EPUB reader. No account. No ads. No friction. Just books.
+            </p>
+            <div class="g-hero__ctas">
+              <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener" class="play-badge">
+                <svg width="20" height="22" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+                </svg>
+                <span class="play-badge__text">
+                  <span class="play-badge__sub">Get it on</span>
+                  <span class="play-badge__main">Google Play</span>
+                </span>
+              </a>
+              <a href="#features" class="secondary-link">See features →</a>
+            </div>
+            <div class="g-hero__stats">
+              <div>
+                <div class="stat__value">70,000+</div>
+                <div class="stat__label">Free books</div>
+              </div>
+              <span class="stat__sep"></span>
+              <div>
+                <div class="stat__value">None</div>
+                <div class="stat__label">Account required</div>
+              </div>
+              <span class="stat__sep"></span>
+              <div>
+                <div class="stat__value">Always</div>
+                <div class="stat__label">Reads offline</div>
+              </div>
+            </div>
+          </div>
+          <div class="g-hero__art">
+            <div class="g-hero__glow"></div>
+            <div class="g-hero__phone-1">
+              <div class="phone" style="--s:0.85; --r:-4deg">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/library.png" alt="Guten library" /></div>
+              </div>
+            </div>
+            <div class="g-hero__phone-2">
+              <div class="phone" style="--s:0.95; --r:4deg">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/home.png" alt="Guten home" /></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ CATALOG ============ -->
+      <section class="catalog">
+        <div class="catalog__art">
+          <div class="catalog__glow"></div>
+          <div class="catalog__phone-1">
+            <div class="phone" style="--s:0.6; --r:-5deg">
+              <div class="phone-screen"><img src="../assets/screenshots/guten/browse.png" alt="Guten browse" /></div>
+            </div>
+          </div>
+          <div class="catalog__phone-2">
+            <div class="phone" style="--s:0.6; --r:4deg">
+              <div class="phone-screen"><img src="../assets/screenshots/guten/import.png" alt="Guten import" /></div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <span class="eyebrow">The whole catalog</span>
+          <div style="height:18px"></div>
+          <h2 class="catalog__title">
+            Seventy thousand <em>classics</em>, in your pocket.
+          </h2>
+          <p class="catalog__body">
+            Search the catalog within Guten and tap to download. Found a Gutenberg book in your browser? Share the link directly to Guten, or enter the ebook number, and import.
+          </p>
+          <div class="catalog__chips">
+            <span class="author-chip">Austen</span>
+            <span class="author-chip">Aurelius</span>
+            <span class="author-chip">Plato</span>
+            <span class="author-chip">Wilde</span>
+            <span class="author-chip">Stoker</span>
+            <span class="author-chip">Shelley</span>
+            <span class="author-chip">Melville</span>
+            <span class="author-chip">Homer</span>
+            <span class="author-chip">Tolstoy</span>
+            <span class="author-chip">Dickens</span>
+            <span class="author-chip">Dostoevsky</span>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ FEATURES ============ -->
+      <section id="features" class="features">
+        <div class="features__header">
+          <div>
+            <span class="eyebrow">Built for real readers</span>
+            <h2 class="features__title">
+              A reader that gets out of <em>the way</em>.
+            </h2>
+          </div>
+          <p class="features__support">
+            No social feed. No recommendation algorithm shouting at you. Just a typeset page, your library, and the tools to read deeply.
+          </p>
+        </div>
+
+        <div class="features__grid">
+          <div class="feature">
+            <div class="feature__num">i</div>
+            <div class="feature__art">
+              <div class="phone" style="--s:0.55">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/reading_sepia.png" alt="Guten sepia reading screen" /></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="feature__title">Read offline, your way</h3>
+              <p class="feature__body">Adjustable font, spacing, and Light / Sepia / Dark themes. Wi-Fi-only download keeps you in control on metered plans.</p>
+            </div>
+          </div>
+
+          <div class="feature">
+            <div class="feature__num">ii</div>
+            <div class="feature__art">
+              <div class="phone" style="--s:0.55">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/reading_dark.png" alt="Guten dark reading screen" /></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="feature__title">Highlight &amp; annotate</h3>
+              <p class="feature__body">Mark passages, attach notes, and insert bookmarks. Your notes survive even if you remove the book file.</p>
+            </div>
+          </div>
+
+          <div class="feature">
+            <div class="feature__num">iii</div>
+            <div class="feature__art">
+              <div class="phone" style="--s:0.55">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/search.png" alt="Guten search screen" /></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="feature__title">Search every word</h3>
+              <p class="feature__body">Search the current chapter or the whole book. Jump between matches and return to where you were.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ THEMES ============ -->
+      <section class="themes">
+        <div class="themes__header">
+          <div class="themes__eyebrow">Three themes</div>
+          <h2 class="themes__title">
+            Read in <em>any</em> light.
+          </h2>
+          <p class="themes__body">
+            Light for the morning commute. Sepia for the afternoon. Dark for after midnight. Or follow your system — Guten will swap quietly.
+          </p>
+        </div>
+        <div class="themes__row">
+          <div class="theme">
+            <div class="phone" style="--s:0.78">
+              <div class="phone-screen"><img src="../assets/screenshots/guten/reading_light.png" alt="Light theme" /></div>
+            </div>
+            <div class="theme__caption"><span class="theme__num">i</span>Light</div>
+          </div>
+          <div class="theme">
+            <div class="phone" style="--s:0.78">
+              <div class="phone-screen"><img src="../assets/screenshots/guten/reading_sepia.png" alt="Sepia theme" /></div>
+            </div>
+            <div class="theme__caption"><span class="theme__num">ii</span>Sepia</div>
+          </div>
+          <div class="theme">
+            <div class="phone" style="--s:0.78">
+              <div class="phone-screen"><img src="../assets/screenshots/guten/reading_dark.png" alt="Dark theme" /></div>
+            </div>
+            <div class="theme__caption"><span class="theme__num">iii</span>Dark</div>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ HABITS ============ -->
+      <section class="habits">
+        <div>
+          <span class="eyebrow">Daily habit</span>
+          <h2 class="habits__title">A few quiet minutes, every day.</h2>
+          <p class="habits__body">
+            Set a goal in minutes. Watch your streak grow. See total reading time, books finished, and what's next, all on one calm dashboard.
+          </p>
+          <ul class="habits__list">
+            <li>Daily reading goal in minutes</li>
+            <li>Current and longest streak</li>
+            <li>Books completed &amp; total time</li>
+            <li>Continue where you left off</li>
+          </ul>
+        </div>
+        <div class="habits__art">
+          <div class="habits__quote">&ldquo;3 of 20 min today · 1 day streak&rdquo;</div>
+          <div class="phone" style="--s:0.95">
+            <div class="phone-screen"><img src="../assets/screenshots/guten/home.png" alt="Guten home dashboard" /></div>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ PREMIUM ============ -->
+      <section class="premium">
+        <div class="premium__header">
+          <div class="premium__eyebrow">Premium</div>
+          <h2 class="premium__title">
+            Go <em>further</em>, when you're ready.
+          </h2>
+          <p class="premium__body">
+            A one-time purchase. No subscription. Everything in the free reader stays free — Premium just adds the tools deeper readers tend to want.
+          </p>
+        </div>
+
+        <div class="premium__pill-wrap">
+          <div class="premium__pill">One-time purchase · No subscription</div>
+        </div>
+
+        <div class="premium__grid">
+          <div class="premium-card">
+            <div class="premium-card__num">i</div>
+            <div class="premium-card__art">
+              <div class="phone" style="--s:0.55">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/read_aloud.png" alt="Read Aloud" /></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="premium-card__title">Read Aloud</h3>
+              <p class="premium-card__body">Text-to-speech with variable speed (0.5×–3×), tap-to-speak, chapter-to-chapter background playback, and a media notification.</p>
+            </div>
+          </div>
+
+          <div class="premium-card">
+            <div class="premium-card__num">ii</div>
+            <div class="premium-card__art">
+              <div class="phone" style="--s:0.55">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/reading_timer.png" alt="Pomodoro reading timer" /></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="premium-card__title">Pomodoro reading timer</h3>
+              <p class="premium-card__body">Focused sessions with break prompts. Set reading and rest, hit start.</p>
+            </div>
+          </div>
+
+          <div class="premium-card">
+            <div class="premium-card__num">iii</div>
+            <div class="premium-card__art">
+              <div class="phone" style="--s:0.55">
+                <div class="phone-screen"><img src="../assets/screenshots/guten/export.png" alt="Notes and export" /></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="premium-card__title">Notes &amp; export</h3>
+              <p class="premium-card__body">Search, filter, and bulk-export every highlight and note across your library — Markdown (Wikilinks or standard), CSV, JSON, or plain text.</p>
+            </div>
+          </div>
+
+          <div class="premium-card">
+            <div class="premium-card__num">iv</div>
+            <div class="premium-card__shelves">
+              <div class="shelves-list">
+                <div class="shelf-row"><span><span class="shelf-row__num">i</span>To Read</span><span class="shelf-row__count">12</span></div>
+                <div class="shelf-row"><span><span class="shelf-row__num">ii</span>Favorites</span><span class="shelf-row__count">7</span></div>
+                <div class="shelf-row"><span><span class="shelf-row__num">iii</span>Stoics</span><span class="shelf-row__count">4</span></div>
+                <div class="shelf-row"><span><span class="shelf-row__num">iv</span>Re-read</span><span class="shelf-row__count">3</span></div>
+              </div>
+            </div>
+            <div>
+              <h3 class="premium-card__title">Collections</h3>
+              <p class="premium-card__body">Organize your library into custom shelves like &ldquo;To Read,&rdquo; &ldquo;Favorites,&rdquo; or &ldquo;Stoics.&rdquo;</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ BOTTOM CTA ============ -->
+      <section class="g-cta">
+        <span class="eyebrow" style="margin-bottom:24px">Free · No account · 70,000+ books</span>
+        <h2 class="g-cta__title">
+          Start with <em>Pride and Prejudice</em>,<br>
+          <em>Meditations</em>, or <em>The Art of War</em>.
+        </h2>
+        <p class="g-cta__body">
+          Guten is free to download. Premium is a one-time purchase — no subscription, ever.
+        </p>
+        <div class="g-cta__action">
+          <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener" class="play-badge play-badge--lg">
+            <svg width="22" height="24.2" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+              <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+              <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+              <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+              <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+            </svg>
+            <span class="play-badge__text">
+              <span class="play-badge__sub">Get it on</span>
+              <span class="play-badge__main">Google Play</span>
+            </span>
+          </a>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="site-footer__grid">
+        <div class="site-footer__brand">
+          <img src="../icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
+          <div>
+            <div class="site-footer__brand-name">ULIX</div>
+            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
+          </div>
+        </div>
+        <div class="site-footer__links">
+          <a href="../apps.html">Apps</a>
+          <a href="../blog.html">Blog</a>
+          <a href="../support.html">Support</a>
+          <a href="../about.html">About</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../terms.html">Terms</a>
+          <a href="../privacy.html">Privacy</a>
+          <a href="../gutenprivacy.html">Guten Privacy</a>
+        </div>
+        <div>
+          <form action="https://buttondown.com/api/emails/embed-subscribe/ulix" method="post" target="bd-subscribe" class="newsletter" aria-label="Email signup">
+            <label for="nl-email" class="newsletter__label">Get product updates</label>
+            <div class="newsletter__row">
+              <input id="nl-email" class="newsletter__input" type="email" name="email" placeholder="you@example.com" />
+              <button class="btn btn--secondary">Subscribe</button>
+            </div>
+          </form>
+          <div class="site-footer__copyright">© 2025 Ulix LLC. Guten is independent and not affiliated with Project Gutenberg®.</div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/ulix.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -65,4 +65,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://ulix.app/guten/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
Added a dedicated landing page for Guten, the free EPUB reader app, featuring a complete product showcase with hero section, feature highlights, theme previews, premium tier information, and multiple calls-to-action.

## Key Changes
- **New landing page** (`guten/index.html`): Comprehensive 1100+ line HTML page with:
  - Scoped CSS styling with warm dark color palette (dark background with gold accents)
  - Hero section with dual phone mockups showcasing library and home screens
  - Catalog section highlighting 70,000+ free public-domain books
  - Features section (3 columns) covering offline reading, annotations, and search
  - Themes showcase (Light, Sepia, Dark) with phone mockups
  - Habits/dashboard section with reading goal tracking
  - Premium tier section (4 features) with Read Aloud, Pomodoro timer, notes export, and collections
  - Bottom CTA section with prominent Google Play download button
  - Responsive design with mobile breakpoints
  - Full SEO metadata, Open Graph tags, and schema.org structured data

- **Updated sitemap** (`sitemap.xml`): Added new Guten landing page URL with monthly changefreq and 0.8 priority

- **Updated apps page** (`apps.html`): Modified Guten app card to link to the new dedicated landing page instead of external resources

## Implementation Details
- Uses existing Ulix design system (fonts, components, layout patterns) while applying custom warm-dark theme via CSS custom properties
- Phone frame component with CSS scaling and rotation for flexible mockup display
- Gradient glows and subtle animations (hover states on buttons)
- Comprehensive responsive design with single breakpoint at 900px
- Semantic HTML with proper heading hierarchy and ARIA labels
- Multiple CTAs linking to Google Play Store

https://claude.ai/code/session_01P8UwxBt2cBhUWsdsAYHQ1s