### PR TITLE
Switch Guten section numerals to uppercase sans style

### DIFF
--- a/guten/index.html
+++ b/guten/index.html
@@ -419,11 +419,12 @@
     gap: 24px;
   }
   .guten-page .feature__num {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 13px;
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
     color: var(--accent);
-    letter-spacing: 0.04em;
   }
   .guten-page .feature__art {
     background: var(--card-bg);
@@ -487,15 +488,7 @@
     text-transform: uppercase;
     color: var(--subtle);
   }
-  .guten-page .theme__num {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 13px;
-    letter-spacing: 0.04em;
-    text-transform: none;
-    color: var(--accent);
-    margin-right: 10px;
-  }
+  .guten-page .theme__num { color: var(--accent); margin-right: 10px; }
 
   /* ---------- Habits section ---------- */
   .guten-page .habits {
@@ -621,11 +614,12 @@
     gap: 20px;
   }
   .guten-page .premium-card__num {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 13px;
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
     color: var(--accent);
-    letter-spacing: 0.04em;
   }
   .guten-page .premium-card__art {
     background: var(--card-bg);


### PR DESCRIPTION
Re-lands PR #47, which was merged into the stale `claude/review-guten-fonts-OAtss` feature branch instead of `new` and never reached the default branch.

Switches the section numerals on `/guten` from Newsreader italic lowercase ("i / ii / iii") to the uppercase sans tracked style ("I / II / III"), matching eyebrows and the theme caption.

## Changes
- `.feature__num`, `.premium-card__num`: Geist 11px / weight 500 / `letter-spacing: 0.3em` / `text-transform: uppercase`, accent gold.
- `.theme__num`: minimal form, inherits parent caption's uppercase sans.

## Test plan
- [ ] `/guten` renders "I", "II", "III" uppercase across Features, Themes, Premium.
- [ ] Numerals visually consistent across all three sections.
- [ ] Mobile (≤900px) caption layout still aligns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQMziMEgsduDcyFAnwKwdF)_