### PR TITLE
Tighten Guten hero and emphasize free badge

### DIFF
--- a/guten/index.html
+++ b/guten/index.html
@@ -220,20 +220,6 @@
   .guten-page .play-badge__main { font-size: 17px; font-weight: 600; letter-spacing: -0.02em; }
   .guten-page .play-badge--lg .play-badge__sub { font-size: 11px; }
   .guten-page .play-badge--lg .play-badge__main { font-size: 18.7px; }
-  .guten-page .play-badge-wrap {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-  }
-  .guten-page .play-badge__caption {
-    font-family: var(--sans);
-    font-size: 11px;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--accent);
-    font-weight: 600;
-  }
 
   /* ---------- Secondary link ---------- */
   .guten-page .secondary-link {
@@ -793,9 +779,9 @@
 
       <!-- ============ HERO ============ -->
       <section class="g-hero">
+        <span class="eyebrow g-hero__free-chip">Free · No account · 70,000+ books</span>
         <div class="g-hero__grid">
           <div>
-            <span class="eyebrow g-hero__free-chip">Free · No account · 70,000+ books</span>
             <h1 class="g-hero__title">
               Read more.<br>
               <em>Scroll less.</em>
@@ -804,21 +790,18 @@
               Guten is a free Android ereader for 70,000+ public-domain books from Project Gutenberg. Search the catalog, download books, read offline, and take notes. No account. No ads. Just books.
             </p>
             <div class="g-hero__ctas">
-              <div class="play-badge-wrap">
-                <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener" class="play-badge">
-                  <svg width="20" height="22" viewBox="0 0 20 22" fill="none" aria-hidden="true">
-                    <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
-                    <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
-                    <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
-                    <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
-                  </svg>
-                  <span class="play-badge__text">
-                    <span class="play-badge__sub">Get it on</span>
-                    <span class="play-badge__main">Google Play</span>
-                  </span>
-                </a>
-                <span class="play-badge__caption">Free download · No ads</span>
-              </div>
+              <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener" class="play-badge">
+                <svg width="20" height="22" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+                </svg>
+                <span class="play-badge__text">
+                  <span class="play-badge__sub">Get it free on</span>
+                  <span class="play-badge__main">Google Play</span>
+                </span>
+              </a>
               <a href="#features" class="secondary-link">See features →</a>
             </div>
             <div class="g-hero__stats">
@@ -1097,7 +1080,7 @@
               <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
             </svg>
             <span class="play-badge__text">
-              <span class="play-badge__sub">Get it on</span>
+              <span class="play-badge__sub">Get it free on</span>
               <span class="play-badge__main">Google Play</span>
             </span>
           </a>


### PR DESCRIPTION
## Summary
- Remove the "Free download · No ads" caption beneath the hero Play badge — it made the hero feel cluttered.
- Move the "Free · No account · 70,000+ books" eyebrow chip up above the hero grid (where the old "Ulix · Reading" eyebrow used to sit) so it has clear separation from the "Read more. Scroll less." headline.
- Change the Play badge subline from "Get it on" to "Get it free on" in both the hero and bottom CTA so the word "free" lives inside the primary CTA itself.

## Test plan
- [ ] Load `/guten/` and confirm the chip sits at the top with breathing room above the H1
- [ ] Confirm the Play badge reads "Get it free on / Google Play" in both placements
- [ ] Check mobile (≤900px): chip → H1 spacing still looks comfortable

---
_Generated by [Claude Code](https://claude.ai/code/session_01HroZ8GuV3HrvU69HAiM1aN)_