### PR TITLE
Remove inaccurate "free" claims (Shelf Scan landing + homepage meta)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ulix — Tools, Not Traps</title>
-  <meta name="description" content="Ulix makes privacy-first Android apps. Free basic features, optional one-time premium purchases. No ads, no tracking, no data brokering." />
+  <meta name="description" content="Ulix makes privacy-first Android apps. No ads, no tracking, no data brokering." />
   <link rel="canonical" href="https://ulix.app/" />
   <meta name="theme-color" content="#00142F" />
 

--- a/shelfscan/index.html
+++ b/shelfscan/index.html
@@ -833,7 +833,7 @@
       <section class="s-hero">
         <div class="s-hero__grid">
           <div>
-            <span class="eyebrow" style="margin-bottom:24px; display:inline-flex;">Free · No accounts · Works offline</span>
+            <span class="eyebrow" style="margin-bottom:24px; display:inline-flex;">Pay once · No accounts · Works offline</span>
             <h1 class="s-hero__title" style="margin-top:18px;">
               Search shelves<br>
               <em>instantly.</em>
@@ -1106,12 +1106,12 @@
 
       <!-- ============ BOTTOM CTA ============ -->
       <section class="s-cta">
-        <span class="eyebrow" style="margin-bottom:24px; justify-content:center;">Free · No accounts · Works offline</span>
+        <span class="eyebrow" style="margin-bottom:24px; justify-content:center;">Pay once · No accounts · Works offline</span>
         <h2 class="s-cta__title" style="margin-top:16px;">
           Organize your library<br>without <em>organizing it</em>.
         </h2>
         <p class="s-cta__body">
-          CTRL+F the World. Download Shelf Scan free on Google Play.
+          CTRL+F the World. Get Shelf Scan on Google Play for $1.99.
         </p>
         <div class="s-cta__action">
           <a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener" class="play-badge play-badge--lg">


### PR DESCRIPTION
## Summary

Shelf Scan is a one-time $1.99 purchase, and the Ulix lineup as a whole is not "free with optional premium." Two places implied otherwise.

**`shelfscan/index.html`** (3 spots)
- Hero eyebrow: `Free · No accounts · Works offline` → `Pay once · No accounts · Works offline`
- Bottom CTA eyebrow: same swap
- Bottom CTA body: `CTRL+F the World. Download Shelf Scan free on Google Play.` → `CTRL+F the World. Get Shelf Scan on Google Play for $1.99.`

**`index.html`** (homepage meta description)
- Was: `Ulix makes privacy-first Android apps. Free basic features, optional one-time premium purchases. No ads, no tracking, no data brokering.`
- Now: `Ulix makes privacy-first Android apps. No ads, no tracking, no data brokering.`

The Shelf Scan JSON-LD on the landing page was already correct (`isAccessibleForFree: false`, `price: "1.99"`). Guten-specific "free with optional premium" copy on `gutenprivacy.html` and `guten/index.html` is left alone because it's accurate for Guten.

## Test plan

- [ ] Open `/shelfscan/` and confirm no "free" copy remains in the hero or bottom CTA
- [ ] Confirm the `Pay once` chip wraps cleanly at mobile widths
- [ ] View source on `/` and confirm the new homepage meta description
- [ ] Spot-check the Rich Results test on `/shelfscan/` still shows price $1.99 USD