### PR TITLE
Style navigation and branding elements for keepclip page

### DIFF
--- a/keepclip/index.html
+++ b/keepclip/index.html
@@ -135,6 +135,10 @@
   }
 
   .keepclip-page a { color: inherit; text-decoration: none; }
+  .keepclip-page .site-brand { color: #fff; }
+  .keepclip-page .site-nav__link { color: rgba(255, 255, 255, 0.8); }
+  .keepclip-page .site-nav__link:hover,
+  .keepclip-page .site-nav__link[aria-current="page"] { color: #fff; }
   .keepclip-page img { display: block; user-select: none; -webkit-user-drag: none; }
   .keepclip-page h1, .keepclip-page h2, .keepclip-page h3 { margin: 0; color: var(--fg); }
   .keepclip-page p, .keepclip-page ul, .keepclip-page figure { margin: 0; }


### PR DESCRIPTION
## Summary
Added CSS styling for navigation and branding elements within the keepclip page to improve visual hierarchy and user experience with proper color contrast.

## Changes
- Added white color styling for `.site-brand` element
- Styled `.site-nav__link` with semi-transparent white (80% opacity) for default state
- Added hover and active state styling for navigation links with full white color for better visibility and feedback

## Implementation Details
The new styles follow the existing keepclip-page styling pattern and maintain consistency with the dark theme by using white text colors. The navigation links use a slightly transparent white for the default state (rgba(255, 255, 255, 0.8)) to create visual distinction from the active/hover states which use full white (#fff), providing clear affordance for interactive elements.

https://claude.ai/code/session_01Vh5gjX4oAEAWhJQ966DW9R