### PR TITLE
Refactor typography and update Google Play icon

### DIFF
--- a/trackanalysis/index.html
+++ b/trackanalysis/index.html
@@ -40,7 +40,7 @@
   <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/geist-latin.woff2" crossorigin />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <style>
     @font-face {
       font-family: 'Geist';
@@ -288,38 +288,13 @@
     --bad:       #F87171;
     --gold:      #E7B770;
     --gold-soft: rgba(231, 183, 112, 0.16);
-    --sans:    'Inter', Geist, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    --display: 'Cormorant Garamond', 'EB Garamond', Georgia, 'Times New Roman', serif;
+    --sans: 'Inter', Geist, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 
     background: var(--bg);
     color: var(--fg);
     font-family: var(--sans);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-  }
-  .ta-page h1, .ta-page h2, .ta-page h3,
-  .ta-page .panel__title,
-  .ta-page .ta-cta__title,
-  .ta-page .section-title,
-  .ta-page .ta-hero__title,
-  .ta-page .compare-card__head,
-  .ta-page .wf-step__title,
-  .ta-page .pro-feature__title {
-    font-family: var(--display);
-    font-weight: 500;
-    letter-spacing: -0.005em;
-  }
-  .ta-page .ta-hero__title,
-  .ta-page .section-title,
-  .ta-page .ta-cta__title,
-  .ta-page .panel__title {
-    font-weight: 500;
-  }
-  .ta-page .ta-hero__title em,
-  .ta-page .section-title em,
-  .ta-page .ta-cta__title em {
-    font-style: italic;
-    font-weight: 500;
   }
 
   .ta-page a { color: inherit; text-decoration: none; }
@@ -440,16 +415,16 @@
     min-height: 620px;
   }
   .ta-page .ta-hero__title {
-    font-size: 72px;
-    font-weight: 500;
-    line-height: 1.04;
-    letter-spacing: -0.015em;
+    font-size: 64px;
+    font-weight: 700;
+    line-height: 1.05;
+    letter-spacing: -0.03em;
     text-wrap: balance;
     color: var(--fg);
     margin-top: 28px;
   }
   .ta-page .ta-hero__title em {
-    font-style: italic;
+    font-style: normal;
     color: var(--accent);
   }
   .ta-page .ta-hero__lede {
@@ -550,7 +525,7 @@
       inset 0 0 0 1px rgba(255,255,255,0.06);
     flex-shrink: 0;
     position: relative;
-    transform: perspective(1200px) rotateY(10deg) rotateX(3deg) rotateZ(3deg);
+    transform: none;
     transform-origin: center center;
     transform-style: preserve-3d;
   }
@@ -653,9 +628,9 @@
 
   /* ---------- Generic section title ---------- */
   .ta-page .section-title {
-    font-size: 44px;
-    font-weight: 500;
-    letter-spacing: -0.01em;
+    font-size: 36px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
     line-height: 1.1;
     color: var(--fg);
     text-align: center;
@@ -850,10 +825,10 @@
   }
   .ta-page .panel__icon svg { width: 32px; height: 32px; }
   .ta-page .panel__title {
-    font-size: 30px;
-    font-weight: 500;
+    font-size: 24px;
+    font-weight: 700;
     color: var(--fg);
-    letter-spacing: -0.005em;
+    letter-spacing: -0.015em;
   }
   .ta-page .panel--pro .panel__title { color: var(--gold); }
   .ta-page .panel__list {
@@ -962,11 +937,11 @@
   }
   .ta-page .ta-cta__lock svg { width: 32px; height: 32px; }
   .ta-page .ta-cta__title {
-    font-size: 40px;
-    font-weight: 500;
+    font-size: 32px;
+    font-weight: 700;
     color: var(--fg);
-    letter-spacing: -0.01em;
-    line-height: 1.1;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
   }
   .ta-page .ta-cta__title em {
     font-style: normal;
@@ -1024,10 +999,10 @@
     .ta-page .ta-hero__grid { grid-template-columns: 1fr; gap: 32px; min-height: 0; }
     .ta-page .ta-hero__art { grid-template-columns: 1fr; min-height: 0; gap: 20px; }
     .ta-page .ta-hero__chips { max-width: none; }
-    .ta-page .ta-hero__title { font-size: 56px; }
-    .ta-page .section-title { font-size: 36px; }
-    .ta-page .ta-cta__title { font-size: 32px; }
-    .ta-page .panel__title { font-size: 26px; }
+    .ta-page .ta-hero__title { font-size: 48px; }
+    .ta-page .section-title { font-size: 32px; }
+    .ta-page .ta-cta__title { font-size: 26px; }
+    .ta-page .panel__title { font-size: 22px; }
     .ta-page .ta-phone-wrap { padding: 0; }
     .ta-page .ta-phone { transform: none; }
 
@@ -1144,13 +1119,39 @@
             </p>
 
             <div class="ta-hero__ctas">
-              <a href="https://play.google.com/store/apps/details?id=com.ulix.trackanalysis" target="_blank" rel="noopener" class="btn-blue">
+              <a href="https://play.google.com/store/apps/details?id=com.ulix.trackanalysis" target="_blank" rel="noopener" class="btn-blue" aria-label="Get Track Analysis on Google Play">
                 Get Track Analysis
-                <svg width="16" height="18" viewBox="0 0 20 22" fill="none" aria-hidden="true">
-                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="currentColor" opacity="0.95"/>
-                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="currentColor" opacity="0.75"/>
-                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="currentColor" opacity="0.6"/>
-                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="currentColor" opacity="0.45"/>
+                <svg width="20" height="22" viewBox="0 0 256 283" aria-hidden="true">
+                  <defs>
+                    <linearGradient id="gp-blue" x1="50%" y1="0%" x2="50%" y2="100%">
+                      <stop offset="0%" stop-color="#00A0FF"/>
+                      <stop offset="26%" stop-color="#00BFFF"/>
+                      <stop offset="51%" stop-color="#00D2FF"/>
+                      <stop offset="76%" stop-color="#00DFFF"/>
+                      <stop offset="100%" stop-color="#00E3FF"/>
+                    </linearGradient>
+                    <linearGradient id="gp-yellow" x1="100%" y1="50%" x2="0%" y2="50%">
+                      <stop offset="0%" stop-color="#FFE000"/>
+                      <stop offset="41%" stop-color="#FFBD00"/>
+                      <stop offset="78%" stop-color="#FFA500"/>
+                      <stop offset="100%" stop-color="#FF9C00"/>
+                    </linearGradient>
+                    <linearGradient id="gp-red" x1="100%" y1="0%" x2="0%" y2="100%">
+                      <stop offset="0%" stop-color="#FF3A44"/>
+                      <stop offset="100%" stop-color="#C31162"/>
+                    </linearGradient>
+                    <linearGradient id="gp-green" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stop-color="#32A071"/>
+                      <stop offset="7%" stop-color="#2DA771"/>
+                      <stop offset="48%" stop-color="#15CF74"/>
+                      <stop offset="80%" stop-color="#06E775"/>
+                      <stop offset="100%" stop-color="#00F076"/>
+                    </linearGradient>
+                  </defs>
+                  <path fill="url(#gp-blue)" d="M2 2 v275 l140 -134 z"/>
+                  <path fill="url(#gp-green)" d="M2 2 l187 99 -47 38 z"/>
+                  <path fill="url(#gp-yellow)" d="M255 142 l-66 -38 -47 38 z"/>
+                  <path fill="url(#gp-red)" d="M142 141 l47 38 -187 99 z"/>
                 </svg>
               </a>
               <a href="#how" class="btn-ghost">


### PR DESCRIPTION
## Summary
This PR modernizes the Track Analysis website's typography system and updates the Google Play button icon. The changes simplify the font stack, adjust heading styles for better visual hierarchy, and replace a custom play icon with the official Google Play Store icon.

## Key Changes
- **Font Stack Simplification**: Removed Cormorant Garamond serif font and consolidated to Inter sans-serif throughout the site, reducing Google Fonts request to a single family with weight 400-800
- **Typography Updates**: 
  - Increased font weights from 500 to 700 for major headings (hero title, section titles, CTA titles, panel titles)
  - Adjusted font sizes across breakpoints for better visual hierarchy
  - Removed italic styling from hero title emphasis elements
  - Updated letter-spacing values for improved readability
- **Hero Section Refinement**: 
  - Reduced hero title from 72px to 64px with increased font weight
  - Removed 3D perspective transform effect on hero image
  - Adjusted line-height and letter-spacing for better proportions
- **Google Play Icon**: Replaced custom play button SVG with official Google Play Store icon featuring the characteristic four-color gradient design
- **Accessibility**: Added `aria-label` to Google Play button for better screen reader support
- **Responsive Design**: Updated tablet breakpoint font sizes to maintain visual consistency with new base sizes

## Implementation Details
- All heading elements now use the `--sans` font variable exclusively
- Removed the `--display` CSS variable and all associated serif font styling rules
- Google Play icon now uses proper SVG gradients matching Google's official branding
- Maintained responsive design patterns while adjusting breakpoint values proportionally

https://claude.ai/code/session_0125fVeAa8E4cAvcHr4DEuPT