### PR TITLE
Update social media preview images for Track Analysis and Keep Clip

### DIFF
--- a/keepclip/index.html
+++ b/keepclip/index.html
@@ -13,11 +13,11 @@
   <meta property="og:title" content="Keep Clip — Save the text you don’t want to lose." />
   <meta property="og:description" content="Private Android app for saving notes, quotes, highlights, excerpts, and links. Offline. No accounts. No ads. Export to Markdown, CSV, TXT, RTF, or HTML." />
   <meta property="og:url" content="https://ulix.app/keepclip/" />
-  <meta property="og:image" content="https://ulix.app/icons/keepclip.png" />
+  <meta property="og:image" content="https://ulix.app/assets/keepclip/keepclipshare.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Keep Clip — Save the text you don’t want to lose." />
   <meta name="twitter:description" content="Private Android app for saving notes, quotes, highlights, excerpts, and links. Offline. No accounts. No ads. Export to Markdown, CSV, TXT, RTF, or HTML." />
-  <meta name="twitter:image" content="https://ulix.app/icons/keepclip.png" />
+  <meta name="twitter:image" content="https://ulix.app/assets/keepclip/keepclipshare.png" />
 
   <link rel="icon" href="../icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="../icons/favicon.png" />

--- a/trackanalysis/index.html
+++ b/trackanalysis/index.html
@@ -22,16 +22,16 @@
   <meta property="og:title" content="Track Analysis — Freeform tracking for self-experimentation." />
   <meta property="og:description" content="Private Android app for plain-English wellness logging. Export clean CSV and use your favorite LLM to find patterns. No accounts. No subscriptions." />
   <meta property="og:url" content="https://ulix.app/trackanalysis/" />
-  <meta property="og:image" content="https://ulix.app/icons/trackanalysis.png" />
-  <meta property="og:image:alt" content="Track Analysis app icon — a cream line chart with a checkmark on a dark blue background." />
-  <meta property="og:image:width" content="512" />
-  <meta property="og:image:height" content="512" />
+  <meta property="og:image" content="https://ulix.app/assets/trackanalysis/trackanalysisshare.png" />
+  <meta property="og:image:alt" content="Track Analysis — freeform wellness tracking for self-experimentation." />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@ulixapp" />
   <meta name="twitter:title" content="Track Analysis — Freeform tracking for self-experimentation." />
   <meta name="twitter:description" content="Private Android app for plain-English wellness logging. Export clean CSV and use your favorite LLM to find patterns. No accounts. No subscriptions." />
-  <meta name="twitter:image" content="https://ulix.app/icons/trackanalysis.png" />
-  <meta name="twitter:image:alt" content="Track Analysis app icon — a cream line chart with a checkmark on a dark blue background." />
+  <meta name="twitter:image" content="https://ulix.app/assets/trackanalysis/trackanalysisshare.png" />
+  <meta name="twitter:image:alt" content="Track Analysis — freeform wellness tracking for self-experimentation." />
 
   <link rel="icon" href="../icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="../icons/favicon.png" />


### PR DESCRIPTION
## Summary
Updated Open Graph and Twitter Card meta tags to use optimized social media preview images instead of app icons for both Track Analysis and Keep Clip applications.

## Key Changes
- **Track Analysis**: 
  - Changed og:image and twitter:image from app icon (`trackanalysis.png`) to a dedicated share image (`trackanalysisshare.png`)
  - Updated image dimensions from 512x512 to 1200x630 (standard social media preview size)
  - Updated image alt text to match the app tagline instead of describing the icon
  
- **Keep Clip**:
  - Changed og:image and twitter:image from app icon (`keepclip.png`) to a dedicated share image (`keepclipshare.png`)
  - Updated image paths to use the new `/assets/` directory structure

## Implementation Details
- Image URLs now point to `/assets/{app}/` directory instead of `/icons/`
- Dimensions changed to 1200x630px, which is the recommended size for social media platforms (Open Graph and Twitter)
- Alt text updated to be more descriptive of the app's purpose rather than the visual appearance of the icon
- Changes applied consistently across both og: and twitter: meta tags

https://claude.ai/code/session_01DcXTJGxxmjr7hhj4r1YaWi