### PR TITLE
Redesign home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,10 +792,10 @@
                 <div class="app-card__tags"><span class="app-tag">Utility</span><span class="soon-badge">Soon</span></div>
               </div>
             </div>
-            <h4 class="app-card__headline">Get your stuff back.</h4>
+            <h4 class="app-card__headline">Record your lending.</h4>
             <p class="app-card__body">
-              Track what you lent, who has it, and what needs to come back.
-              Snap a photo, add a name, get on with your life.
+              Track what you lent, who has it, and when it needs to come back.
+              Add photos, contacts, and reminders.
             </p>
             <ul class="util-feature-list">
               <li>Photo + person + date</li>

--- a/index.html
+++ b/index.html
@@ -774,7 +774,9 @@
               satellites, and more.
             </p>
             <ul class="util-feature-list">
-              <li>BLE · Wi-Fi · Cellular · GNSS · GPS · Signal Strength</li>
+              <li>BLE · Wi-Fi · Cellular</li>
+              <li>GNSS · GPS</li>
+              <li>Signal Strength</li>
               <li>Local CSV export</li>
             </ul>
             <div class="app-card__foot">

--- a/index.html
+++ b/index.html
@@ -3,28 +3,52 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Ulix — Tools, Not Traps</title>
-  <meta name="description" content="Ulix makes privacy-first Android apps. No ads, no tracking, no data brokering." />
+  <title>Ulix — Apps for information people</title>
+  <meta name="description" content="Six Android apps for collecting, searching, scanning, saving, reading, and logging the information in your life — built to help you understand it. Free to start. No accounts. Works offline." />
   <link rel="canonical" href="https://ulix.app/" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
-  <meta property="og:title" content="Ulix — Tools, Not Traps" />
-  <meta property="og:description" content="Privacy-first Android apps. No ads, no tracking, no data brokering." />
+  <meta property="og:title" content="Ulix — Apps for information people" />
+  <meta property="og:description" content="Six Android apps for collecting, searching, scanning, saving, reading, and logging the information in your life — built to help you understand it." />
   <meta property="og:url" content="https://ulix.app/" />
   <meta property="og:image" content="https://ulix.app/icons/favicon.png" />
 
   <!-- Twitter card -->
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="Ulix — Tools, Not Traps" />
-  <meta name="twitter:description" content="Privacy-first Android apps. No ads, no tracking, no data brokering." />
+  <meta name="twitter:title" content="Ulix — Apps for information people" />
+  <meta name="twitter:description" content="Six Android apps for collecting, searching, scanning, saving, reading, and logging the information in your life." />
   <meta name="twitter:image" content="https://ulix.app/icons/favicon.png" />
 
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the app pages. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <style>
+    @font-face {
+      font-family: 'Geist';
+      font-style: normal;
+      font-weight: 100 900;
+      font-display: swap;
+      src: url('./assets/fonts/geist-latin.woff2') format('woff2');
+      unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+      font-family: 'Geist';
+      font-style: normal;
+      font-weight: 100 900;
+      font-display: swap;
+      src: url('./assets/fonts/geist-latin-ext.woff2') format('woff2');
+      unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    }
+  </style>
 
   <script type="application/ld+json">
   {
@@ -36,12 +60,388 @@
     "sameAs": []
   }
   </script>
+
+  <style>
+  /* ==========================================================================
+     Home page — scoped to .home-page
+     --------------------------------------------------------------------------
+     Loaded after ulix.css so these rules win on specificity within the wrapper.
+     Same warm-dark editorial system as the app landing pages (see /guten/),
+     with a blue "information" accent. Gold is reserved for utilities / "soon".
+     ========================================================================== */
+
+  .home-page {
+    --bg: #0F0E0C;
+    --fg: #F4EFE6;
+    --muted: rgba(244,239,230,0.65);
+    --subtle: rgba(244,239,230,0.45);
+    --card-bg: #181614;
+    --rule: rgba(244,239,230,0.12);
+    --accent: #5BA3F5;   /* blue — the "information" accent (italics, numbers) */
+    --gold: #E5B83A;     /* gold — utilities, "soon", coming-this-year */
+    --serif: 'Newsreader', Georgia, serif;
+    --sans: Geist, system-ui, sans-serif;
+
+    /* Override site tokens so the shared header / footer / drawer pick up the
+       warm-dark palette inside this page only. */
+    --ulix-primary: #0F0E0C;
+    --ulix-primary-dark: #0F0E0C;
+    --ulix-accent: #5BA3F5;
+    --ulix-bg: #0F0E0C;
+    --ulix-ink: #F4EFE6;
+
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ---------- Shared chrome tweaks for the warm-dark palette ---------- */
+  .home-page .site-header { border-bottom-color: rgba(244,239,230,0.1); }
+  .home-page .btn--primary {
+    background: var(--fg);
+    color: var(--bg);
+    border-color: var(--fg);
+  }
+  .home-page .btn--primary:hover { background: #fff; }
+  .home-page .btn--secondary,
+  .home-page .btn--header {
+    background: transparent;
+    color: var(--fg);
+    border-color: var(--rule);
+    box-shadow: none;
+  }
+  .home-page .btn--secondary:hover,
+  .home-page .btn--header:hover { border-color: rgba(244,239,230,0.4); }
+  .home-page .site-footer { border-top-color: rgba(244,239,230,0.12); color: rgba(244,239,230,0.7); }
+  .home-page .site-footer__tag,
+  .home-page .site-footer__copyright,
+  .home-page .site-footer__links a { color: rgba(244,239,230,0.7); }
+  .home-page .site-footer__brand-name,
+  .home-page .site-footer__links a:hover { color: var(--fg); }
+  .home-page .newsletter__label { color: rgba(244,239,230,0.8); }
+
+  .home-page a { color: inherit; text-decoration: none; }
+  .home-page img { display: block; user-select: none; -webkit-user-drag: none; }
+  .home-page h1, .home-page h2, .home-page h3, .home-page h4 { margin: 0; color: var(--fg); }
+  .home-page p, .home-page ul { margin: 0; }
+  .home-page ul { list-style: none; padding: 0; }
+  .home-page .page { max-width: 1280px; margin: 0 auto; }
+
+  /* ---------- Phone frame (shared with the app pages) ---------- */
+  .home-page .phone {
+    width: calc(280px * var(--s, 1));
+    height: calc(580px * var(--s, 1));
+    border-radius: calc(38px * var(--s, 1));
+    padding: calc(8px * var(--s, 1));
+    background: linear-gradient(180deg, #1a1a1a 0%, #050505 100%);
+    box-shadow:
+      0 calc(30px * var(--s, 1)) calc(80px * var(--s, 1)) rgba(0,0,0,0.35),
+      0 calc(4px * var(--s, 1)) calc(12px * var(--s, 1)) rgba(0,0,0,0.18),
+      inset 0 0 0 1px rgba(255,255,255,0.06);
+    transform: rotate(var(--r, 0deg));
+    flex-shrink: 0;
+    position: relative;
+  }
+  .home-page .phone-screen {
+    width: 100%;
+    height: 100%;
+    border-radius: calc(30px * var(--s, 1));
+    overflow: hidden;
+    background: #000;
+  }
+  .home-page .phone-screen img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: top;
+  }
+  /* "Coming soon" placeholder screen for unreleased apps */
+  .home-page .phone-screen--soon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    text-align: center;
+    padding: 24px;
+    background:
+      radial-gradient(120% 80% at 50% 0%, rgba(91,163,245,0.10), transparent 60%),
+      #0c0b0a;
+  }
+  .home-page .phone-screen--soon img { width: 30%; max-width: 72px; height: auto; border-radius: 16px; }
+  .home-page .soon-screen__name { font-family: var(--serif); font-size: 19px; color: var(--fg); }
+  .home-page .soon-screen__label {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 10.5px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted);
+  }
+  .home-page .soon-screen__label::before {
+    content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--gold);
+  }
+
+  /* ---------- Eyebrow (numbered section label) ---------- */
+  .home-page .sec-eyebrow { display: flex; flex-direction: column; gap: 10px; }
+  .home-page .sec-eyebrow__num {
+    font-family: var(--serif);
+    font-size: 15px;
+    color: var(--accent);
+    letter-spacing: 0.04em;
+  }
+  .home-page .sec-eyebrow__label {
+    font-family: var(--sans);
+    font-size: 11px;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: var(--subtle);
+    font-weight: 500;
+  }
+
+  /* ---------- Section divider ---------- */
+  .home-page .divider { height: 1px; background: var(--rule); margin: 0 80px; }
+
+  /* ---------- Play badge (shared with the app pages) ---------- */
+  .home-page .play-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: #0F0E0C;
+    color: var(--fg);
+    padding: 13px 20px;
+    border-radius: 999px;
+    font-family: var(--sans);
+    font-weight: 500;
+    border: 1px solid #2a2724;
+    box-shadow: 0 1px 0 rgba(255,255,255,0.04) inset;
+    transition: transform 0.15s;
+  }
+  .home-page .play-badge:hover { transform: translateY(-1px); }
+  .home-page .play-badge__text { display: flex; flex-direction: column; line-height: 1.1; text-align: left; }
+  .home-page .play-badge__sub { font-size: 10px; opacity: 0.65; letter-spacing: 0.08em; text-transform: uppercase; }
+  .home-page .play-badge__main { font-size: 16px; font-weight: 600; letter-spacing: -0.02em; }
+
+  /* ---------- Inline "more" links ---------- */
+  .home-page .more-link {
+    display: inline-flex; align-items: center; gap: 7px;
+    font-family: var(--sans); font-size: 14px; font-weight: 500;
+    color: var(--fg); white-space: nowrap;
+  }
+  .home-page .more-link:hover { gap: 10px; }
+  .home-page .more-link--gold { color: var(--gold); }
+  .home-page .secondary-link {
+    display: inline-flex; align-items: center; gap: 8px;
+    color: rgba(244,239,230,0.75); font-family: var(--sans);
+    font-size: 15px; font-weight: 500; padding: 12px 4px;
+    border-bottom: 1px solid rgba(244,239,230,0.25);
+  }
+  .home-page .secondary-link:hover { color: var(--fg); }
+
+  /* =========================== HERO =========================== */
+  .home-page .home-hero {
+    padding: 64px 80px 88px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+  }
+  .home-page .home-hero__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(46px, 7.6vw, 96px);
+    line-height: 0.98;
+    letter-spacing: -0.025em;
+    text-wrap: balance;
+    max-width: 16ch;
+    margin: 0 auto;
+  }
+  .home-page .home-hero__title em { font-style: italic; color: var(--accent); }
+  .home-page .home-hero__lede {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(17px, 1.9vw, 22px);
+    line-height: 1.5;
+    color: var(--muted);
+    max-width: 640px;
+    margin: 28px auto 0;
+  }
+  .home-page .home-hero__ctas {
+    margin-top: 36px;
+    display: flex; gap: 24px; align-items: center; justify-content: center; flex-wrap: wrap;
+  }
+  .home-page .home-hero__pills {
+    margin-top: 40px;
+    display: flex; gap: 12px 28px; justify-content: center; flex-wrap: wrap;
+  }
+  .home-page .hero-pill {
+    display: inline-flex; align-items: center; gap: 10px;
+    font-size: 13px; color: var(--muted); letter-spacing: 0.01em;
+  }
+  .home-page .hero-pill::before {
+    content: ""; width: 5px; height: 5px; background: var(--accent);
+    transform: rotate(45deg); flex-shrink: 0;
+  }
+  .home-page .hero-phones {
+    position: relative;
+    margin-top: 72px;
+    min-height: 460px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .home-page .hero-phones__glow {
+    position: absolute; inset: 0;
+    background: radial-gradient(46% 60% at 50% 45%, rgba(91,163,245,0.16), transparent 70%);
+    filter: blur(50px); pointer-events: none;
+  }
+  .home-page .hero-phones__row {
+    position: relative;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .home-page .hero-phones__row .phone { margin: 0 -16px; }
+
+  /* =========================== NUMBERED SECTIONS =========================== */
+  .home-page .sec { padding: 92px 80px; }
+  .home-page .sec__head {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 60px;
+    align-items: end; margin-bottom: 60px;
+  }
+  .home-page .sec__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(34px, 5vw, 58px);
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    margin-top: 20px;
+    max-width: 600px;
+    text-wrap: balance;
+  }
+  .home-page .sec__title em { font-style: italic; color: var(--accent); }
+  .home-page .sec__support {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--muted);
+    max-width: 430px;
+    justify-self: end;
+  }
+
+  /* ---------- App cards ---------- */
+  .home-page .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px; }
+  .home-page .cards--utility { gap: 24px; }
+  .home-page .app-card {
+    border: 1px solid var(--rule);
+    border-radius: 16px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.025), transparent 55%);
+    padding: 28px;
+    display: flex; flex-direction: column; gap: 18px;
+  }
+  .home-page .app-card:hover { border-color: rgba(244,239,230,0.22); }
+  .home-page .app-card__head { display: flex; align-items: center; gap: 14px; }
+  .home-page .app-card__icon { width: 42px; height: 42px; border-radius: 10px; flex-shrink: 0; }
+  .home-page .app-card__name { font-family: var(--serif); font-size: 22px; font-weight: 500; line-height: 1; }
+  .home-page .app-card__tags { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
+  .home-page .app-tag {
+    font-family: var(--sans); font-size: 10px; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--subtle); font-weight: 500;
+  }
+  .home-page .soon-badge {
+    font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--gold);
+    border: 1px solid rgba(229,184,58,0.4); border-radius: 999px; padding: 2px 8px; font-weight: 500;
+  }
+  .home-page .app-card__headline {
+    font-family: var(--serif); font-weight: 500; font-size: 25px;
+    letter-spacing: -0.015em; line-height: 1.12; color: var(--fg);
+  }
+  .home-page .app-card__body { font-size: 14.5px; line-height: 1.55; color: var(--muted); }
+  .home-page .app-card__art {
+    background: var(--card-bg);
+    border: 1px solid rgba(244,239,230,0.05);
+    border-radius: 12px;
+    height: 300px;
+    display: flex; justify-content: center; align-items: flex-end;
+    padding-top: 30px;
+    overflow: hidden;
+  }
+  .home-page .app-card__art--sm { height: 250px; }
+  .home-page .tag-pills { display: flex; flex-wrap: wrap; gap: 8px; }
+  .home-page .tag-pills li {
+    display: inline-flex; align-items: center; gap: 8px;
+    border: 1px solid var(--rule); border-radius: 999px;
+    padding: 6px 12px; font-size: 12px; color: var(--muted);
+  }
+  .home-page .tag-pills li::before {
+    content: ""; width: 5px; height: 5px; border-radius: 50%; background: var(--accent); flex-shrink: 0;
+  }
+  .home-page .app-card__foot {
+    margin-top: auto; padding-top: 4px;
+    display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap;
+  }
+  .home-page .coming-chip {
+    display: inline-flex; align-items: center; gap: 9px;
+    font-size: 13px; color: var(--muted);
+    border: 1px dashed var(--rule); border-radius: 999px; padding: 9px 14px;
+  }
+  .home-page .coming-chip::before {
+    content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--gold); flex-shrink: 0;
+  }
+
+  /* =========================== CLOSING CTA =========================== */
+  .home-page .home-cta { padding: 116px 80px; text-align: center; }
+  .home-page .home-cta__title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(40px, 6.6vw, 88px);
+    line-height: 0.99;
+    letter-spacing: -0.025em;
+    text-wrap: balance;
+    max-width: 18ch;
+    margin: 18px auto 0;
+  }
+  .home-page .home-cta__title em { font-style: italic; color: var(--accent); }
+  .home-page .home-cta__body {
+    font-family: var(--serif); font-weight: 300; font-size: 19px;
+    color: var(--muted); max-width: 560px; margin: 28px auto 0; line-height: 1.5;
+  }
+  .home-page .home-cta__ctas {
+    margin-top: 40px; display: flex; gap: 24px; align-items: center; justify-content: center; flex-wrap: wrap;
+  }
+  .home-page .home-cta__icons {
+    margin-top: 64px; display: flex; gap: 18px; justify-content: center; align-items: center; flex-wrap: wrap;
+  }
+  .home-page .home-cta__icons a { display: block; transition: transform 0.15s; }
+  .home-page .home-cta__icons a:hover { transform: translateY(-3px); }
+  .home-page .home-cta__icons img { width: 54px; height: 54px; border-radius: 13px; border: 1px solid var(--rule); }
+
+  /* =========================== RESPONSIVE =========================== */
+  @media (max-width: 1024px) {
+    .home-page .cards { grid-template-columns: 1fr 1fr; }
+    .home-page .hero-phones__row .phone:nth-child(1),
+    .home-page .hero-phones__row .phone:nth-child(5) { display: none; }
+  }
+  @media (max-width: 760px) {
+    .home-page .divider { margin: 0 24px; }
+    .home-page .home-hero { padding: 40px 24px 56px; }
+    .home-page .home-hero__pills { gap: 10px 20px; }
+    .home-page .hero-phones { margin-top: 48px; min-height: 0; }
+    .home-page .hero-phones__row .phone { margin: 0 -10px; }
+    .home-page .hero-phones__row .phone:nth-child(2),
+    .home-page .hero-phones__row .phone:nth-child(4) { display: none; }
+
+    .home-page .sec { padding: 60px 24px; }
+    .home-page .sec__head { grid-template-columns: 1fr; gap: 16px; margin-bottom: 40px; }
+    .home-page .sec__support { justify-self: start; }
+    .home-page .cards { grid-template-columns: 1fr; gap: 20px; }
+    .home-page .app-card__art { height: 280px; }
+
+    .home-page .home-cta { padding: 72px 24px; }
+    .home-page .home-cta__icons { gap: 14px; }
+    .home-page .home-cta__icons img { width: 46px; height: 46px; }
+  }
+  </style>
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
-  <!-- Header -->
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
     <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
@@ -63,7 +463,7 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
@@ -91,100 +491,331 @@
   </div>
 
   <main id="main">
-    <!-- Hero wordmark -->
-    <section class="hero">
-      <div class="container container--wide">
-        <img src="./icons/ulixwordmarkclear.png" alt="Ulix wordmark" class="hero__wordmark" />
-      </div>
-    </section>
+    <div class="page">
 
-    <!-- Tagline + carousel -->
-    <section class="split">
-      <div class="container container--wide">
-        <div class="split__grid">
-          <div class="split__text">
-            <h1 class="split__tagline">Tools, Not Traps</h1>
-            <p class="split__lede">
-              Apps designed to serve you, not sell you. Elegant and distraction-free,
-              with no ads, no tracking, no attention hacking, and no intrusive permissions.
-            </p>
-            <div class="split__ctas">
-              <a href="./apps.html" class="btn btn--primary">Explore Apps</a>
-              <a href="./about.html" class="btn btn--secondary">Why Ulix?</a>
+      <!-- ============ HERO ============ -->
+      <section class="home-hero">
+        <!-- EDIT: hero headline + lede -->
+        <h1 class="home-hero__title">Apps for <em>information</em> people.</h1>
+        <p class="home-hero__lede">
+          Six Android apps for collecting, searching, scanning, saving, reading, and
+          logging the information in your life — built to help you understand it.
+        </p>
+        <div class="home-hero__ctas">
+          <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>
+          <a href="./about.html" class="secondary-link">About Ulix →</a>
+        </div>
+        <ul class="home-hero__pills">
+          <li class="hero-pill">Six apps</li>
+          <li class="hero-pill">Android</li>
+          <li class="hero-pill">Free to start</li>
+          <li class="hero-pill">No accounts required</li>
+          <li class="hero-pill">Works offline</li>
+        </ul>
+
+        <div class="hero-phones" aria-hidden="false">
+          <div class="hero-phones__glow"></div>
+          <div class="hero-phones__row">
+            <div class="phone" style="--s:0.6; --r:-9deg; z-index:1;">
+              <div class="phone-screen"><img src="./assets/screenshots/trackanalysis/trackanalysis-main-dark.png" alt="Track Analysis logging screen" /></div>
+            </div>
+            <div class="phone" style="--s:0.66; --r:-4.5deg; z-index:2;">
+              <div class="phone-screen"><img src="./assets/screenshots/shelfscan/Shelf%20Scan%20Live%20Mode%20Total.png" alt="Shelf Scan live camera mode" /></div>
+            </div>
+            <div class="phone" style="--s:0.74; --r:0deg; z-index:3;">
+              <div class="phone-screen"><img src="./assets/screenshots/guten/reading_dark.png" alt="Guten reading view" /></div>
+            </div>
+            <div class="phone" style="--s:0.66; --r:4.5deg; z-index:2;">
+              <div class="phone-screen"><img src="./assets/screenshots/keepclip/keepclipmain.png" alt="Keep Clip saved clips" /></div>
+            </div>
+            <div class="phone" style="--s:0.6; --r:9deg; z-index:1;">
+              <div class="phone-screen"><img src="./assets/screenshots/guten/library.png" alt="Guten library" /></div>
             </div>
           </div>
+        </div>
+      </section>
 
+      <div class="divider"></div>
+
+      <!-- ============ 01 · THE FLAGSHIP APPS ============ -->
+      <section class="sec">
+        <div class="sec__head">
           <div>
-            <div class="carousel" data-carousel-region
-                 role="region" aria-roledescription="carousel" aria-label="Featured apps">
-              <div class="carousel__viewport">
-                <div id="product-carousel-track" class="carousel__track" aria-live="polite"></div>
-              </div>
-              <div class="carousel__controls">
-                <button type="button" class="carousel__btn" data-carousel-prev aria-label="Previous slide">
-                  <svg aria-hidden="true" viewBox="0 0 16 16"><path d="M10 2L4 8l6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                </button>
-                <div id="product-carousel-dots" class="carousel__dots" role="tablist" aria-label="Choose slide"></div>
-                <button type="button" class="carousel__btn" data-carousel-next aria-label="Next slide">
-                  <svg aria-hidden="true" viewBox="0 0 16 16"><path d="M6 2l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                </button>
-                <button type="button" class="carousel__btn" data-carousel-pause aria-label="Pause carousel" aria-pressed="false"></button>
+            <div class="sec-eyebrow">
+              <span class="sec-eyebrow__num">01</span>
+              <span class="sec-eyebrow__label">The flagship apps</span>
+            </div>
+            <!-- EDIT: section title -->
+            <h2 class="sec__title">Start with one of these <em>three</em>.</h2>
+          </div>
+          <!-- EDIT: section support -->
+          <p class="sec__support">
+            Each one is a focused tool for collecting, searching, or saving information.
+            They share the same calm, careful feel — and they get out of your way.
+          </p>
+        </div>
+
+        <div class="cards">
+
+          <!-- Guten -->
+          <article class="app-card">
+            <div class="app-card__head">
+              <img src="./icons/guten.png" alt="" class="app-card__icon" />
+              <div>
+                <h3 class="app-card__name">Guten</h3>
+                <div class="app-card__tags"><span class="app-tag">Flagship</span></div>
               </div>
             </div>
-          </div>
-        </div>
-      </div>
-    </section>
+            <h4 class="app-card__headline">A reader for the classics.</h4>
+            <p class="app-card__body">
+              Discover, download, and read 70,000+ free public-domain books from Project
+              Gutenberg. Read offline, highlight passages, take notes, build a daily habit. No account.
+            </p>
+            <div class="app-card__art">
+              <div class="phone" style="--s:0.62"><div class="phone-screen"><img src="./assets/screenshots/guten/reading_dark.png" alt="Guten reading view" /></div></div>
+            </div>
+            <ul class="tag-pills">
+              <li>70,000+ books</li>
+              <li>Read offline</li>
+              <li>Notes &amp; highlights</li>
+            </ul>
+            <div class="app-card__foot">
+              <a href="https://play.google.com/store/apps/details?id=com.bhunt.guten" target="_blank" rel="noopener" class="play-badge">
+                <svg width="18" height="20" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+                </svg>
+                <span class="play-badge__text">
+                  <span class="play-badge__sub">Get it on</span>
+                  <span class="play-badge__main">Google Play</span>
+                </span>
+              </a>
+              <a href="./guten/" class="more-link">Learn more →</a>
+            </div>
+          </article>
 
-    <!-- Why Ulix -->
-    <section class="section section--bg">
-      <div class="container container--wide">
-        <div class="grid grid--4">
-          <div class="card">
-            <h3 class="card__title">Privacy First</h3>
-            <p class="card__text">
-              Local-first architecture with offline capability. No ads, tracking, or unnecessary accounts —
-              because your data should remain yours.
+          <!-- Shelf Scan -->
+          <article class="app-card">
+            <div class="app-card__head">
+              <img src="./icons/shelfscan.png" alt="" class="app-card__icon" />
+              <div>
+                <h3 class="app-card__name">Shelf Scan</h3>
+                <div class="app-card__tags"><span class="app-tag">Flagship</span></div>
+              </div>
+            </div>
+            <h4 class="app-card__headline">See what's on your shelf.</h4>
+            <p class="app-card__body">
+              Point your camera at a shelf and search the text on every spine and cover —
+              like Ctrl-F for the physical world. Books, films, games. Works entirely offline.
             </p>
-          </div>
-          <div class="card">
-            <h3 class="card__title">Curated by Design</h3>
-            <p class="card__text">
-              Apps shaped by our founder's aesthetic vision. We build for those who share our particular
-              sensibilities and design philosophy.
-            </p>
-          </div>
-          <div class="card">
-            <h3 class="card__title">Focused Tools</h3>
-            <p class="card__text">
-              Clean, purposeful interfaces that enhance your life without demanding constant attention
-              or engagement.
-            </p>
-          </div>
-          <div class="card">
-            <h3 class="card__title">Built on Products, Not Data</h3>
-            <p class="card__text">
-              We build our revenue around our products, not your data. It's a deliberate choice that
-              shapes everything we create.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
+            <div class="app-card__art">
+              <div class="phone" style="--s:0.62"><div class="phone-screen"><img src="./assets/screenshots/shelfscan/Shelf%20Scan%20Live%20Mode%20Total.png" alt="Shelf Scan live camera mode" /></div></div>
+            </div>
+            <ul class="tag-pills">
+              <li>Camera search</li>
+              <li>Fully offline</li>
+              <li>Nothing leaves device</li>
+            </ul>
+            <div class="app-card__foot">
+              <a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener" class="play-badge">
+                <svg width="18" height="20" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+                </svg>
+                <span class="play-badge__text">
+                  <span class="play-badge__sub">Get it on</span>
+                  <span class="play-badge__main">Google Play</span>
+                </span>
+              </a>
+              <a href="./shelfscan/" class="more-link">Learn more →</a>
+            </div>
+          </article>
 
-    <!-- Featured apps -->
-    <section class="section">
-      <div class="container">
-        <div class="section-head">
-          <h2 class="section-head__title">Featured Apps</h2>
-          <a href="./apps.html" class="btn btn--secondary">View All</a>
+          <!-- Keep Clip -->
+          <article class="app-card">
+            <div class="app-card__head">
+              <img src="./icons/keepclip.png" alt="" class="app-card__icon" />
+              <div>
+                <h3 class="app-card__name">Keep Clip</h3>
+                <div class="app-card__tags"><span class="app-tag">Flagship</span></div>
+              </div>
+            </div>
+            <h4 class="app-card__headline">Save the text you don't want to lose.</h4>
+            <p class="app-card__body">
+              Capture quotes, highlights, and links from almost any app with Share — websites,
+              ebooks, documents, chats. Tag, search, and export to Markdown, CSV, and more. Offline by default.
+            </p>
+            <div class="app-card__art">
+              <div class="phone" style="--s:0.62"><div class="phone-screen"><img src="./assets/screenshots/keepclip/keepclipmain.png" alt="Keep Clip saved clips" /></div></div>
+            </div>
+            <ul class="tag-pills">
+              <li>Capture anywhere</li>
+              <li>Tags &amp; search</li>
+              <li>Markdown export</li>
+            </ul>
+            <div class="app-card__foot">
+              <a href="https://play.google.com/store/apps/details?id=com.bhunt.keepclip" target="_blank" rel="noopener" class="play-badge">
+                <svg width="18" height="20" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+                </svg>
+                <span class="play-badge__text">
+                  <span class="play-badge__sub">Get it on</span>
+                  <span class="play-badge__main">Google Play</span>
+                </span>
+              </a>
+              <a href="./keepclip/" class="more-link">Learn more →</a>
+            </div>
+          </article>
+
         </div>
-        <div id="featured-apps" class="grid grid--3"></div>
-      </div>
-    </section>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ 02 · THE UTILITIES ============ -->
+      <section class="sec">
+        <div class="sec__head">
+          <div>
+            <div class="sec-eyebrow">
+              <span class="sec-eyebrow__num">02</span>
+              <span class="sec-eyebrow__label">The utilities</span>
+            </div>
+            <!-- EDIT: section title -->
+            <h2 class="sec__title">Three more, <em>smaller</em> in scope.</h2>
+          </div>
+          <!-- EDIT: section support -->
+          <p class="sec__support">
+            Small, friendly tools for very specific kinds of information.
+            Two are still in the workshop.
+          </p>
+        </div>
+
+        <div class="cards cards--utility">
+
+          <!-- Track Analysis -->
+          <article class="app-card">
+            <div class="app-card__head">
+              <img src="./icons/trackanalysis.png" alt="" class="app-card__icon" />
+              <div>
+                <h3 class="app-card__name">Track Analysis</h3>
+                <div class="app-card__tags"><span class="app-tag">Utility</span></div>
+              </div>
+            </div>
+            <h4 class="app-card__headline">A private record of how you feel.</h4>
+            <p class="app-card__body">Private health logging, then export.</p>
+            <div class="app-card__art app-card__art--sm">
+              <div class="phone" style="--s:0.6"><div class="phone-screen"><img src="./assets/screenshots/trackanalysis/trackanalysis-main-dark.png" alt="Track Analysis logging screen" /></div></div>
+            </div>
+            <div class="app-card__foot">
+              <a href="https://play.google.com/store/apps/details?id=com.ulix.trackanalysis" target="_blank" rel="noopener" class="play-badge">
+                <svg width="18" height="20" viewBox="0 0 20 22" fill="none" aria-hidden="true">
+                  <path d="M1 1.5v19l10-9.5L1 1.5z" fill="#E5B83A" opacity="0.95"/>
+                  <path d="M1 1.5l10 9.5 3-3L2.5 1 1 1.5z" fill="#E5B83A" opacity="0.7"/>
+                  <path d="M1 20.5l10-9.5 3 3L2.5 21 1 20.5z" fill="#E5B83A" opacity="0.55"/>
+                  <path d="M11 11l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 3v16l4.5-2.5c1.2-.7 1.2-2.3 0-3L11 11z" fill="#E5B83A" opacity="0.4"/>
+                </svg>
+                <span class="play-badge__text">
+                  <span class="play-badge__sub">Get it on</span>
+                  <span class="play-badge__main">Google Play</span>
+                </span>
+              </a>
+              <a href="./trackanalysis/" class="more-link more-link--gold">Details →</a>
+            </div>
+          </article>
+
+          <!-- Curious Air -->
+          <article class="app-card">
+            <div class="app-card__head">
+              <img src="./icons/curiousair.png" alt="" class="app-card__icon" />
+              <div>
+                <h3 class="app-card__name">Curious Air</h3>
+                <div class="app-card__tags"><span class="app-tag">Utility</span><span class="soon-badge">Soon</span></div>
+              </div>
+            </div>
+            <h4 class="app-card__headline">See what's broadcasting.</h4>
+            <p class="app-card__body">Explore the signals around you.</p>
+            <div class="app-card__art app-card__art--sm">
+              <div class="phone" style="--s:0.6">
+                <div class="phone-screen phone-screen--soon">
+                  <img src="./icons/curiousair.png" alt="" />
+                  <span class="soon-screen__name">Curious Air</span>
+                  <span class="soon-screen__label">Coming this year</span>
+                </div>
+              </div>
+            </div>
+            <div class="app-card__foot">
+              <span class="coming-chip">Coming this year</span>
+              <a href="./apps.html" class="more-link more-link--gold">Details →</a>
+            </div>
+          </article>
+
+          <!-- Loan It -->
+          <article class="app-card">
+            <div class="app-card__head">
+              <img src="./icons/loanit.png" alt="" class="app-card__icon" />
+              <div>
+                <h3 class="app-card__name">Loan It</h3>
+                <div class="app-card__tags"><span class="app-tag">Utility</span><span class="soon-badge">Soon</span></div>
+              </div>
+            </div>
+            <h4 class="app-card__headline">Get your stuff back.</h4>
+            <p class="app-card__body">Track what you've lent out.</p>
+            <div class="app-card__art app-card__art--sm">
+              <div class="phone" style="--s:0.6">
+                <div class="phone-screen phone-screen--soon">
+                  <img src="./icons/loanit.png" alt="" />
+                  <span class="soon-screen__name">Loan It</span>
+                  <span class="soon-screen__label">Coming this year</span>
+                </div>
+              </div>
+            </div>
+            <div class="app-card__foot">
+              <span class="coming-chip">Coming this year</span>
+              <a href="./apps.html" class="more-link more-link--gold">Details →</a>
+            </div>
+          </article>
+
+        </div>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ============ 03 · ALL SIX APPS (closing CTA) ============ -->
+      <section class="home-cta">
+        <div class="sec-eyebrow" style="align-items:center; display:inline-flex;">
+          <span class="sec-eyebrow__num">03</span>
+          <span class="sec-eyebrow__label">All six apps</span>
+        </div>
+        <!-- EDIT: closing title + body -->
+        <h2 class="home-cta__title">Find the app for the <em>information</em> you keep.</h2>
+        <p class="home-cta__body">
+          Free to start. No accounts. Built for Android, by a small team that uses every one of them.
+        </p>
+        <div class="home-cta__ctas">
+          <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>
+          <a href="./about.html" class="secondary-link">About Ulix →</a>
+        </div>
+        <div class="home-cta__icons">
+          <a href="./guten/" aria-label="Guten"><img src="./icons/guten.png" alt="Guten" /></a>
+          <a href="./shelfscan/" aria-label="Shelf Scan"><img src="./icons/shelfscan.png" alt="Shelf Scan" /></a>
+          <a href="./keepclip/" aria-label="Keep Clip"><img src="./icons/keepclip.png" alt="Keep Clip" /></a>
+          <a href="./trackanalysis/" aria-label="Track Analysis"><img src="./icons/trackanalysis.png" alt="Track Analysis" /></a>
+          <a href="./apps.html" aria-label="Curious Air"><img src="./icons/curiousair.png" alt="Curious Air" /></a>
+          <a href="./apps.html" aria-label="Loan It"><img src="./icons/loanit.png" alt="Loan It" /></a>
+        </div>
+      </section>
+
+    </div>
   </main>
 
-  <!-- Footer -->
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
       <div class="site-footer__grid">
@@ -212,7 +843,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
   .home-page .site-footer__brand-name,
   .home-page .site-footer__links a:hover { color: var(--fg); }
   .home-page .newsletter__label { color: rgba(244,239,230,0.8); }
-  .home-page .footer-wordmark { height: 88px; width: auto; opacity: 0.92; }
+  .home-page .footer-wordmark { height: 108px; width: auto; opacity: 0.92; }
   .home-page .footer-credo {
     text-align: center;
     font-family: var(--serif);

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
         <!-- EDIT: closing title + body -->
         <h2 class="home-cta__title">Find the app for the <em>information</em> you keep.</h2>
         <p class="home-cta__body">
-          No accounts. No ads. Built for Android, by someone who uses every one of them.
+          No accounts. No ads. Android apps built by someone who uses every one of them.
         </p>
         <div class="home-cta__ctas">
           <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>

--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
     line-height: 0.98;
     letter-spacing: -0.025em;
     text-wrap: balance;
-    max-width: 16ch;
+    max-width: 24ch;
     margin: 0 auto;
   }
   .home-page .home-hero__title em { font-style: italic; color: var(--accent); }
@@ -260,7 +260,7 @@
     font-size: clamp(17px, 1.9vw, 22px);
     line-height: 1.5;
     color: var(--muted);
-    max-width: 640px;
+    max-width: 760px;
     margin: 28px auto 0;
   }
   .home-page .home-hero__ctas {
@@ -543,15 +543,15 @@
           <div>
             <div class="sec-eyebrow">
               <span class="sec-eyebrow__num">01</span>
-              <span class="sec-eyebrow__label">The flagship apps</span>
+              <span class="sec-eyebrow__label">Books · Shelves · Text</span>
             </div>
             <!-- EDIT: section title -->
-            <h2 class="sec__title">Start with one of these <em>three</em>.</h2>
+            <h2 class="sec__title">Apps for <em>readers</em>.</h2>
           </div>
           <!-- EDIT: section support -->
           <p class="sec__support">
-            Each one is a focused tool for collecting, searching, or saving information.
-            They share the same calm, careful feel — and they get out of your way.
+            Apps to help you find the book, read the book, and save the best
+            of what you’ve read.
           </p>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -121,6 +121,19 @@
   .home-page .site-footer__brand-name,
   .home-page .site-footer__links a:hover { color: var(--fg); }
   .home-page .newsletter__label { color: rgba(244,239,230,0.8); }
+  .home-page .footer-wordmark { height: 70px; width: auto; opacity: 0.92; }
+  .home-page .footer-credo {
+    text-align: center;
+    font-family: var(--serif);
+    font-size: clamp(15px, 1.7vw, 19px);
+    line-height: 1.5;
+    color: var(--muted);
+    padding-bottom: 28px;
+    margin-bottom: 32px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .home-page .footer-credo b { color: var(--fg); font-weight: 400; }
+  .home-page .footer-credo .sep { color: var(--accent); padding: 0 4px; }
 
   .home-page a { color: inherit; text-decoration: none; }
   .home-page img { display: block; user-select: none; -webkit-user-drag: none; }
@@ -381,6 +394,18 @@
   }
   .home-page .coming-chip::before {
     content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--gold); flex-shrink: 0;
+  }
+
+  /* ---------- Utility feature list (per-card brand accent) ---------- */
+  .home-page .app-card--util { --util-accent: var(--accent); }
+  .home-page .util-feature-list { display: flex; flex-direction: column; gap: 11px; margin-top: 4px; }
+  .home-page .util-feature-list li {
+    display: flex; align-items: center; gap: 11px;
+    font-family: var(--sans); font-size: 11px; font-weight: 500;
+    letter-spacing: 0.11em; text-transform: uppercase; color: var(--muted);
+  }
+  .home-page .util-feature-list li::before {
+    content: ""; width: 7px; height: 7px; flex-shrink: 0; background: var(--util-accent);
   }
 
   /* =========================== CLOSING CTA =========================== */
@@ -688,19 +713,18 @@
               <span class="sec-eyebrow__label">The utilities</span>
             </div>
             <!-- EDIT: section title -->
-            <h2 class="sec__title">Three more, <em>smaller</em> in scope.</h2>
+            <h2 class="sec__title">Ulix <em>utilities</em>.</h2>
           </div>
           <!-- EDIT: section support -->
           <p class="sec__support">
-            Small, friendly tools for very specific kinds of information.
-            Two are still in the workshop.
+            Tools for specific kinds of information. Two are still in the workshop.
           </p>
         </div>
 
         <div class="cards cards--utility">
 
           <!-- Track Analysis -->
-          <article class="app-card">
+          <article class="app-card app-card--util" style="--util-accent:#5BA3F5;">
             <div class="app-card__head">
               <img src="./icons/trackanalysis.png" alt="" class="app-card__icon" />
               <div>
@@ -709,10 +733,16 @@
               </div>
             </div>
             <h4 class="app-card__headline">A private record of how you feel.</h4>
-            <p class="app-card__body">Private health logging, then export.</p>
-            <div class="app-card__art app-card__art--sm">
-              <div class="phone" style="--s:0.6"><div class="phone-screen"><img src="./assets/screenshots/trackanalysis/trackanalysis-main-dark.png" alt="Track Analysis logging screen" /></div></div>
-            </div>
+            <p class="app-card__body">
+              Plain-English logs. CSV export. Pattern finding with the LLM you choose.
+              For people who want a wellness journal that's actually theirs.
+            </p>
+            <ul class="util-feature-list">
+              <li>Free-text notes · No forms</li>
+              <li>CSV export · Plain text</li>
+              <li>BYO-LLM analysis</li>
+              <li>100% offline</li>
+            </ul>
             <div class="app-card__foot">
               <a href="https://play.google.com/store/apps/details?id=com.ulix.trackanalysis" target="_blank" rel="noopener" class="play-badge">
                 <svg width="18" height="20" viewBox="0 0 20 22" fill="none" aria-hidden="true">
@@ -731,7 +761,7 @@
           </article>
 
           <!-- Curious Air -->
-          <article class="app-card">
+          <article class="app-card app-card--util" style="--util-accent:#5AC8E0;">
             <div class="app-card__head">
               <img src="./icons/curiousair.png" alt="" class="app-card__icon" />
               <div>
@@ -740,16 +770,16 @@
               </div>
             </div>
             <h4 class="app-card__headline">See what's broadcasting.</h4>
-            <p class="app-card__body">Explore the signals around you.</p>
-            <div class="app-card__art app-card__art--sm">
-              <div class="phone" style="--s:0.6">
-                <div class="phone-screen phone-screen--soon">
-                  <img src="./icons/curiousair.png" alt="" />
-                  <span class="soon-screen__name">Curious Air</span>
-                  <span class="soon-screen__label">Coming this year</span>
-                </div>
-              </div>
-            </div>
+            <p class="app-card__body">
+              Inspect the signals your device can detect: Bluetooth, Wi-Fi, and nearby
+              device traces. For the curious — not the paranoid.
+            </p>
+            <ul class="util-feature-list">
+              <li>BLE · Wi-Fi · Device traces</li>
+              <li>Signal strength · Proximity</li>
+              <li>Read-only · No scans broadcast</li>
+              <li>Local CSV export</li>
+            </ul>
             <div class="app-card__foot">
               <span class="coming-chip">Coming this year</span>
               <a href="./apps.html" class="more-link more-link--gold">Details →</a>
@@ -757,7 +787,7 @@
           </article>
 
           <!-- Loan It -->
-          <article class="app-card">
+          <article class="app-card app-card--util" style="--util-accent:#52C07A;">
             <div class="app-card__head">
               <img src="./icons/loanit.png" alt="" class="app-card__icon" />
               <div>
@@ -766,16 +796,16 @@
               </div>
             </div>
             <h4 class="app-card__headline">Get your stuff back.</h4>
-            <p class="app-card__body">Track what you've lent out.</p>
-            <div class="app-card__art app-card__art--sm">
-              <div class="phone" style="--s:0.6">
-                <div class="phone-screen phone-screen--soon">
-                  <img src="./icons/loanit.png" alt="" />
-                  <span class="soon-screen__name">Loan It</span>
-                  <span class="soon-screen__label">Coming this year</span>
-                </div>
-              </div>
-            </div>
+            <p class="app-card__body">
+              Track what you lent, who has it, and what needs to come back.
+              Snap a photo, add a name, get on with your life.
+            </p>
+            <ul class="util-feature-list">
+              <li>Photo + person + date</li>
+              <li>Return reminders</li>
+              <li>Books · Tools · Anything</li>
+              <li>No accounts</li>
+            </ul>
             <div class="app-card__foot">
               <span class="coming-chip">Coming this year</span>
               <a href="./apps.html" class="more-link more-link--gold">Details →</a>
@@ -791,12 +821,12 @@
       <section class="home-cta">
         <div class="sec-eyebrow" style="align-items:center; display:inline-flex;">
           <span class="sec-eyebrow__num">03</span>
-          <span class="sec-eyebrow__label">All six apps</span>
+          <span class="sec-eyebrow__label">Ulix — Precision tools for modern odysseys</span>
         </div>
         <!-- EDIT: closing title + body -->
         <h2 class="home-cta__title">Find the app for the <em>information</em> you keep.</h2>
         <p class="home-cta__body">
-          Free to start. No accounts. Built for Android, by a small team that uses every one of them.
+          No accounts. No ads. Built for Android by someone who uses every one of them.
         </p>
         <div class="home-cta__ctas">
           <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>
@@ -818,13 +848,10 @@
   <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>

--- a/index.html
+++ b/index.html
@@ -400,12 +400,12 @@
   .home-page .app-card--util { --util-accent: var(--accent); }
   .home-page .util-feature-list { display: flex; flex-direction: column; gap: 11px; margin-top: 4px; }
   .home-page .util-feature-list li {
-    display: flex; align-items: center; gap: 11px;
+    display: flex; align-items: flex-start; gap: 11px;
     font-family: var(--sans); font-size: 11px; font-weight: 500;
-    letter-spacing: 0.11em; text-transform: uppercase; color: var(--muted);
+    letter-spacing: 0.11em; line-height: 1.5; text-transform: uppercase; color: var(--muted);
   }
   .home-page .util-feature-list li::before {
-    content: ""; width: 7px; height: 7px; flex-shrink: 0; background: var(--util-accent);
+    content: ""; width: 7px; height: 7px; margin-top: 4px; flex-shrink: 0; background: var(--util-accent);
   }
 
   /* =========================== CLOSING CTA =========================== */
@@ -732,14 +732,13 @@
                 <div class="app-card__tags"><span class="app-tag">Utility</span></div>
               </div>
             </div>
-            <h4 class="app-card__headline">A private record of how you feel.</h4>
+            <h4 class="app-card__headline">Tracking for analysis.</h4>
             <p class="app-card__body">
               Plain-English logs. CSV export. Pattern finding with the LLM you choose.
-              For people who want a wellness journal that's actually theirs.
             </p>
             <ul class="util-feature-list">
               <li>Free-text notes · No forms</li>
-              <li>CSV export · Plain text</li>
+              <li>CSV export</li>
               <li>BYO-LLM analysis</li>
               <li>100% offline</li>
             </ul>
@@ -771,13 +770,11 @@
             </div>
             <h4 class="app-card__headline">See what's broadcasting.</h4>
             <p class="app-card__body">
-              Inspect the signals your device can detect: Bluetooth, Wi-Fi, and nearby
-              device traces. For the curious — not the paranoid.
+              Explore the signals in the air around you. Wi-Fi, Cellular, Bluetooth,
+              satellites, and more.
             </p>
             <ul class="util-feature-list">
-              <li>BLE · Wi-Fi · Device traces</li>
-              <li>Signal strength · Proximity</li>
-              <li>Read-only · No scans broadcast</li>
+              <li>BLE · Wi-Fi · Cellular · GNSS · GPS · Signal Strength</li>
               <li>Local CSV export</li>
             </ul>
             <div class="app-card__foot">

--- a/index.html
+++ b/index.html
@@ -498,19 +498,19 @@
         <!-- EDIT: hero headline + lede -->
         <h1 class="home-hero__title">Apps for <em>information</em> people.</h1>
         <p class="home-hero__lede">
-          Six Android apps for collecting, searching, scanning, saving, reading, and
-          logging the information in your life — built to help you understand it.
+          Android apps for readers, collectors, researchers, and anyone who loves
+          books, text, notes, and records. Useful software without accounts, ads,
+          tracking, or lock-in.
         </p>
         <div class="home-hero__ctas">
           <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>
           <a href="./about.html" class="secondary-link">About Ulix →</a>
         </div>
         <ul class="home-hero__pills">
-          <li class="hero-pill">Six apps</li>
           <li class="hero-pill">Android</li>
-          <li class="hero-pill">Free to start</li>
-          <li class="hero-pill">No accounts required</li>
-          <li class="hero-pill">Works offline</li>
+          <li class="hero-pill">No accounts</li>
+          <li class="hero-pill">No ads</li>
+          <li class="hero-pill">No tracking</li>
         </ul>
 
         <div class="hero-phones" aria-hidden="false">
@@ -523,13 +523,13 @@
               <div class="phone-screen"><img src="./assets/screenshots/shelfscan/Shelf%20Scan%20Live%20Mode%20Total.png" alt="Shelf Scan live camera mode" /></div>
             </div>
             <div class="phone" style="--s:0.74; --r:0deg; z-index:3;">
-              <div class="phone-screen"><img src="./assets/screenshots/guten/reading_dark.png" alt="Guten reading view" /></div>
+              <div class="phone-screen"><img src="./assets/screenshots/guten/home.png" alt="Guten home screen" /></div>
             </div>
             <div class="phone" style="--s:0.66; --r:4.5deg; z-index:2;">
               <div class="phone-screen"><img src="./assets/screenshots/keepclip/keepclipmain.png" alt="Keep Clip saved clips" /></div>
             </div>
             <div class="phone" style="--s:0.6; --r:9deg; z-index:1;">
-              <div class="phone-screen"><img src="./assets/screenshots/guten/library.png" alt="Guten library" /></div>
+              <div class="phone-screen"><img src="./assets/screenshots/guten/reading_dark.png" alt="Guten dark reading view" /></div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@
               <img src="./icons/guten.png" alt="" class="app-card__icon" />
               <div>
                 <h3 class="app-card__name">Guten</h3>
-                <div class="app-card__tags"><span class="app-tag">Flagship</span></div>
+                <div class="app-card__tags"><span class="app-tag">For long-form reading</span></div>
               </div>
             </div>
             <h4 class="app-card__headline">A reader for the classics.</h4>
@@ -602,13 +602,13 @@
               <img src="./icons/shelfscan.png" alt="" class="app-card__icon" />
               <div>
                 <h3 class="app-card__name">Shelf Scan</h3>
-                <div class="app-card__tags"><span class="app-tag">Flagship</span></div>
+                <div class="app-card__tags"><span class="app-tag">Search your world</span></div>
               </div>
             </div>
-            <h4 class="app-card__headline">See what's on your shelf.</h4>
+            <h4 class="app-card__headline">Find what's on your shelf.</h4>
             <p class="app-card__body">
-              Point your camera at a shelf and search the text on every spine and cover —
-              like Ctrl-F for the physical world. Books, films, games. Works entirely offline.
+              Find books, movies, and games by pointing your camera at your shelves.
+              Save shelf photos and search them anytime. No cataloging. No setup. CTRL+F the world.
             </p>
             <div class="app-card__art">
               <div class="phone" style="--s:0.62"><div class="phone-screen"><img src="./assets/screenshots/shelfscan/Shelf%20Scan%20Live%20Mode%20Total.png" alt="Shelf Scan live camera mode" /></div></div>

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
         <!-- EDIT: closing title + body -->
         <h2 class="home-cta__title">Find the app for the <em>information</em> you keep.</h2>
         <p class="home-cta__body">
-          No accounts. No ads. Built for Android by someone who uses every one of them.
+          No accounts. No ads. Built for Android, by someone who uses every one of them.
         </p>
         <div class="home-cta__ctas">
           <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
   .home-page .site-footer__brand-name,
   .home-page .site-footer__links a:hover { color: var(--fg); }
   .home-page .newsletter__label { color: rgba(244,239,230,0.8); }
-  .home-page .footer-wordmark { height: 70px; width: auto; opacity: 0.92; }
+  .home-page .footer-wordmark { height: 88px; width: auto; opacity: 0.92; }
   .home-page .footer-credo {
     text-align: center;
     font-family: var(--serif);

--- a/index.html
+++ b/index.html
@@ -710,7 +710,7 @@
           <div>
             <div class="sec-eyebrow">
               <span class="sec-eyebrow__num">02</span>
-              <span class="sec-eyebrow__label">The utilities</span>
+              <span class="sec-eyebrow__label">One job, done well</span>
             </div>
             <!-- EDIT: section title -->
             <h2 class="sec__title">Ulix <em>utilities</em>.</h2>

--- a/index.html
+++ b/index.html
@@ -641,13 +641,13 @@
               <img src="./icons/keepclip.png" alt="" class="app-card__icon" />
               <div>
                 <h3 class="app-card__name">Keep Clip</h3>
-                <div class="app-card__tags"><span class="app-tag">Flagship</span></div>
+                <div class="app-card__tags"><span class="app-tag">For text and link collectors</span></div>
               </div>
             </div>
             <h4 class="app-card__headline">Save the text you don't want to lose.</h4>
             <p class="app-card__body">
-              Capture quotes, highlights, and links from almost any app with Share — websites,
-              ebooks, documents, chats. Tag, search, and export to Markdown, CSV, and more. Offline by default.
+              Capture quotes and links from almost any app with Share. Tag, filter,
+              search, star, and export to your format of choice.
             </p>
             <div class="app-card__art">
               <div class="phone" style="--s:0.62"><div class="phone-screen"><img src="./assets/screenshots/keepclip/keepclipmain.png" alt="Keep Clip saved clips" /></div></div>
@@ -655,7 +655,7 @@
             <ul class="tag-pills">
               <li>Capture anywhere</li>
               <li>Tags &amp; search</li>
-              <li>Markdown export</li>
+              <li>MD, CSV, HTML, TXT, and RTF export</li>
             </ul>
             <div class="app-card__foot">
               <a href="https://play.google.com/store/apps/details?id=com.bhunt.keepclip" target="_blank" rel="noopener" class="play-badge">


### PR DESCRIPTION
## Summary
Complete redesign of the Ulix home page with a new warm-dark editorial aesthetic, updated messaging, and a structured showcase of all six apps (three flagship apps and three utilities).

## Key Changes

- **Visual Identity**: Shifted from cool blue (`#00142F`) to warm dark palette (`#0F0E0C` background, `#F4EFE6` foreground) with blue accent (`#5BA3F5`) for information and gold (`#E5B83A`) for utilities/coming-soon items
- **Typography**: Added Geist (self-hosted) and Newsreader (Google Fonts) for a serif/sans-serif editorial system matching the app landing pages
- **Messaging**: Updated tagline from "Tools, Not Traps" to "Apps for information people" with refined meta descriptions emphasizing the six-app ecosystem
- **Layout**: Replaced carousel-based hero with a new multi-section structure:
  - Hero section with phone gallery (5 devices at varying scales and rotations)
  - Section 01: Three flagship apps (Guten, Shelf Scan, Keep Clip) with detailed cards
  - Section 02: Three utilities (Track Analysis, Curious Air, Loan It) with feature lists
  - Section 03: Closing CTA with all six app icons
- **App Cards**: New card design with app icon, headline, description, feature pills/lists, phone mockup, and Play Store badge
- **Responsive Design**: Mobile-first breakpoints at 1024px and 760px with adaptive grid layouts and hidden phone elements
- **Footer**: Added editorial credo ("Find the book · Save the passage...") with wordmark and updated copyright year to 2026
- **Header**: Updated primary CTA text from "Explore Apps" to "Browse all apps →"

## Implementation Details

- Scoped all new styles to `.home-page` wrapper to avoid conflicts with shared site chrome (header/footer)
- Used CSS custom properties for theming (colors, fonts) to maintain consistency
- Implemented phone frame component with scale and rotation variables for flexible positioning
- Added utility-specific accent colors via `--util-accent` CSS variable per card
- Maintained accessibility with proper semantic HTML, ARIA labels, and skip links
- All new content is static HTML (no JavaScript carousel or dynamic rendering)

https://claude.ai/code/session_01V2VJ1pnDZXjnkaC5TFmQaf