### PR TITLE
Home: swipeable hero carousel on mobile + shorten CTA label

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,10 +445,30 @@
     .home-page .divider { margin: 0 24px; }
     .home-page .home-hero { padding: 40px 24px 56px; }
     .home-page .home-hero__pills { gap: 10px 20px; }
-    .home-page .hero-phones { margin-top: 48px; min-height: 0; }
-    .home-page .hero-phones__row .phone { margin: 0 -10px; }
+    .home-page .hero-phones { margin-top: 44px; min-height: 0; }
+    /* Mobile: swipeable carousel of all five screens (instead of one) */
+    .home-page .hero-phones__row {
+      width: 100%;
+      justify-content: flex-start;
+      gap: 12px;
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+      padding: 8px calc(50% - 105px);
+    }
+    .home-page .hero-phones__row::-webkit-scrollbar { display: none; }
+    .home-page .hero-phones__row .phone {
+      margin: 0;
+      transform: none;
+      scroll-snap-align: center;
+      --s: 0.75 !important;
+    }
+    .home-page .hero-phones__row .phone:nth-child(1),
     .home-page .hero-phones__row .phone:nth-child(2),
-    .home-page .hero-phones__row .phone:nth-child(4) { display: none; }
+    .home-page .hero-phones__row .phone:nth-child(4),
+    .home-page .hero-phones__row .phone:nth-child(5) { display: block; }
+    .home-page .hero-phones__row .phone:nth-child(3) { order: -1; }
 
     .home-page .sec { padding: 60px 24px; }
     .home-page .sec__head { grid-template-columns: 1fr; gap: 16px; margin-bottom: 40px; }

--- a/index.html
+++ b/index.html
@@ -548,7 +548,7 @@
           tracking, or lock-in.
         </p>
         <div class="home-hero__ctas">
-          <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>
+          <a href="./apps.html" class="btn btn--primary">Browse all apps</a>
           <a href="./about.html" class="secondary-link">About Ulix →</a>
         </div>
         <ul class="home-hero__pills">
@@ -848,7 +848,7 @@
           No accounts. No ads. Android apps built by someone who uses every one of them.
         </p>
         <div class="home-cta__ctas">
-          <a href="./apps.html" class="btn btn--primary">Browse all six apps</a>
+          <a href="./apps.html" class="btn btn--primary">Browse all apps</a>
           <a href="./about.html" class="secondary-link">About Ulix →</a>
         </div>
         <div class="home-cta__icons">


### PR DESCRIPTION
## Summary

Two follow-up tweaks to the redesigned home page (after #66):

- **Mobile hero carousel** — on screens ≤760px the hero previously collapsed to a single Guten screen. It's now a swipeable scroll‑snap carousel (pure CSS, no JS) showing all five app screens: they snap to center, with the next one peeking to signal swipeability. Leads with the Guten screen for continuity. The desktop/tablet fanned layout is unchanged.
- **CTA label** — "Browse all six apps" → "Browse all apps" on both the hero and closing CTAs, matching the header button.

Scoped to the `.home-page` styles; only `index.html` changes (+25 / −5).

https://claude.ai/code/session_01V2VJ1pnDZXjnkaC5TFmQaf

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2VJ1pnDZXjnkaC5TFmQaf)_