### PR TITLE
Restyle privacy pages to homepage style with a warm-dark prose card

### DIFF
--- a/assets/home.css
+++ b/assets/home.css
@@ -441,3 +441,100 @@
   .home-page .home-cta__icons { gap: 14px; }
   .home-page .home-cta__icons img { width: 46px; height: 46px; }
 }
+
+/* ==========================================================================
+   Long-form document pages (privacy, policies) — the "prose card"
+   --------------------------------------------------------------------------
+   The light theme's nice shadowed .card, re-imagined for the warm-dark palette:
+   a lifted, bordered surface that wraps long-form copy. Used by the privacy
+   pages; reusable by terms / support / any document page.
+   ========================================================================== */
+.home-page .doc { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+
+.home-page .doc-hero { text-align: center; margin-bottom: 36px; }
+.home-page .doc-hero__title {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: clamp(34px, 5.2vw, 56px);
+  line-height: 1.03;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+  color: var(--fg);
+}
+.home-page .doc-hero__title em { font-style: italic; color: var(--accent); }
+.home-page .doc-hero__lede {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: clamp(16px, 1.9vw, 20px);
+  line-height: 1.55;
+  color: var(--muted);
+  max-width: 680px;
+  margin: 20px auto 0;
+}
+.home-page .doc-hero__meta {
+  margin-top: 14px;
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--subtle);
+}
+
+.home-page .prose-card {
+  background: linear-gradient(180deg, rgba(255,255,255,0.035), transparent 55%), var(--card-bg);
+  border: 1px solid var(--rule);
+  border-radius: 18px;
+  padding: clamp(24px, 4.2vw, 44px);
+  box-shadow: 0 24px 60px rgba(0,0,0,0.38), 0 2px 6px rgba(0,0,0,0.22);
+}
+.home-page .prose-card > :first-child { margin-top: 0; }
+
+.home-page .prose-card p {
+  font-family: var(--sans);
+  font-size: 15.5px;
+  line-height: 1.72;
+  color: var(--muted);
+  margin-top: 16px;
+}
+.home-page .prose-card p.lead {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: clamp(18px, 2.1vw, 21px);
+  line-height: 1.5;
+  color: var(--fg);
+}
+.home-page .prose-card h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.2;
+  color: var(--fg);
+  margin-top: 34px;
+}
+.home-page .prose-card ul { margin-top: 14px; display: flex; flex-direction: column; gap: 11px; }
+.home-page .prose-card li {
+  position: relative;
+  padding-left: 22px;
+  font-family: var(--sans);
+  font-size: 15.5px;
+  line-height: 1.62;
+  color: var(--muted);
+}
+.home-page .prose-card li::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 0.62em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.home-page .prose-card a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(91,163,245,0.45);
+}
+.home-page .prose-card a:hover { border-bottom-color: var(--accent); }
+
+@media (max-width: 760px) {
+  .home-page .doc { padding: 40px 18px 64px; }
+}

--- a/gutenprivacy.html
+++ b/gutenprivacy.html
@@ -6,17 +6,26 @@
   <title>Guten — Privacy — Ulix</title>
   <meta name="description" content="How Guten handles your data: local-first reading, minimal diagnostics, no ads, no behavioral tracking." />
   <link rel="canonical" href="https://ulix.app/gutenprivacy.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -36,11 +45,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -63,66 +73,54 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg section--bg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Guten — Privacy Policy</h1>
-        <div class="meta-date">Last updated: April 7, 2026</div>
-
-        <div class="card" style="margin-top:1.5rem">
-          <p class="card__text card__text--base">Guten is a reading app for public-domain books, designed to minimize data collection and keep your reading data under your control.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">What Guten uses the internet for</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Guten uses network access to fetch book listings, metadata, and downloadable book files from third-party public-domain sources, including Gutendex and Project Gutenberg.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">What Guten does not do</h2>
-          <ul class="prose" style="margin-top:0.5rem">
-            <li>No ads</li>
-            <li>No sale of personal data</li>
-            <li>No account required to read books</li>
-          </ul>
-
-          <h2 class="card__title" style="margin-top:1.25rem">Crash and reliability diagnostics (Sentry)</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Guten uses Sentry only to help detect, investigate, and fix crashes or other stability issues so the app stays reliable.</p>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Diagnostics typically include technical details such as app version, operating system version, device model, stack traces, and event timestamps.</p>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Guten’s crash diagnostics are configured to exclude your book library contents and highlights/notes text.</p>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">As part of standard internet request handling, Sentry may process technical identifiers such as IP address. See the <a class="underline-accent" href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer">Sentry Privacy Policy</a> for more detail.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">Data stored on your device</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Your downloaded books and reading data (such as bookmarks, highlights, notes, and reading progress) are stored locally on your device.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">When data may leave your device</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Data leaves your device only when you take an explicit action, such as:</p>
-          <ul class="prose" style="margin-top:0.5rem">
-            <li>opening external links,</li>
-            <li>sharing content through the system share menu, or</li>
-            <li>exporting/backing up your data.</li>
-          </ul>
-
-          <h2 class="card__title" style="margin-top:1.25rem">Your controls</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Guten does not use diagnostics for advertising, cross-app profiling, or behavioral marketing. Diagnostic data is limited to reliability and crash troubleshooting.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">Third-party services</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Guten uses the following third-party services: Gutendex and Project Gutenberg (for catalog and book content), Sentry (for crash and reliability diagnostics), and Google Play Billing (for optional premium purchases). These services may receive standard technical request data (such as IP address and request headers) as part of normal internet communication. Their privacy policies apply to that processing.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">Premium features</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">Guten offers optional premium features (such as text-to-speech, note export, and collections) available as a one-time in-app purchase. Purchases and purchase verification are handled entirely by Google Play Billing. Guten never sees your payment details. When you buy or restore a purchase, Google Play confirms your purchase status to the app; that confirmation is then stored locally on your device. Google's handling of your payment information and purchase history is governed by the Google Play privacy policy.</p>
-
-          <h2 class="card__title" style="margin-top:1.25rem">External websites</h2>
-          <p class="card__text card__text--base" style="margin-top:0.5rem">If you open links to third-party websites, those sites operate under their own privacy policies, independent of Guten.</p>
-        </div>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Guten — Privacy Policy</h1>
+        <div class="doc-hero__meta">Last updated: April 7, 2026</div>
       </div>
-    </section>
+      <div class="prose-card">
+        <p class="lead">Guten is a reading app for public-domain books, designed to minimize data collection and keep your reading data under your control.</p>
+        <h2>What Guten uses the internet for</h2>
+        <p>Guten uses network access to fetch book listings, metadata, and downloadable book files from third-party public-domain sources, including Gutendex and Project Gutenberg.</p>
+        <h2>What Guten does not do</h2>
+        <ul>
+          <li>No ads</li>
+          <li>No sale of personal data</li>
+          <li>No account required to read books</li>
+        </ul>
+        <h2>Crash and reliability diagnostics (Sentry)</h2>
+        <p>Guten uses Sentry only to help detect, investigate, and fix crashes or other stability issues so the app stays reliable.</p>
+        <p>Diagnostics typically include technical details such as app version, operating system version, device model, stack traces, and event timestamps.</p>
+        <p>Guten’s crash diagnostics are configured to exclude your book library contents and highlights/notes text.</p>
+        <p>As part of standard internet request handling, Sentry may process technical identifiers such as IP address. See the <a href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer">Sentry Privacy Policy</a> for more detail.</p>
+        <h2>Data stored on your device</h2>
+        <p>Your downloaded books and reading data (such as bookmarks, highlights, notes, and reading progress) are stored locally on your device.</p>
+        <h2>When data may leave your device</h2>
+        <p>Data leaves your device only when you take an explicit action, such as:</p>
+        <ul>
+          <li>opening external links,</li>
+          <li>sharing content through the system share menu, or</li>
+          <li>exporting/backing up your data.</li>
+        </ul>
+        <h2>Your controls</h2>
+        <p>Guten does not use diagnostics for advertising, cross-app profiling, or behavioral marketing. Diagnostic data is limited to reliability and crash troubleshooting.</p>
+        <h2>Third-party services</h2>
+        <p>Guten uses the following third-party services: Gutendex and Project Gutenberg (for catalog and book content), Sentry (for crash and reliability diagnostics), and Google Play Billing (for optional premium purchases). These services may receive standard technical request data (such as IP address and request headers) as part of normal internet communication. Their privacy policies apply to that processing.</p>
+        <h2>Premium features</h2>
+        <p>Guten offers optional premium features (such as text-to-speech, note export, and collections) available as a one-time in-app purchase. Purchases and purchase verification are handled entirely by Google Play Billing. Guten never sees your payment details. When you buy or restore a purchase, Google Play confirms your purchase status to the app; that confirmation is then stored locally on your device. Google's handling of your payment information and purchase history is governed by the Google Play privacy policy.</p>
+        <h2>External websites</h2>
+        <p>If you open links to third-party websites, those sites operate under their own privacy policies, independent of Guten.</p>
+      </div>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -141,7 +139,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/keepclipprivacypolicy.html
+++ b/keepclipprivacypolicy.html
@@ -6,17 +6,26 @@
   <title>Keep Clip — Privacy — Ulix</title>
   <meta name="description" content="How Keep Clip handles your data: local only, no accounts, no analytics, no advertising." />
   <link rel="canonical" href="https://ulix.app/keepclipprivacypolicy.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -36,11 +45,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -63,34 +73,32 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg section--bg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Keep Clip — Privacy Policy</h1>
-        <div class="card" style="margin-top:1.5rem">
-          <p class="card__text card__text--base">Keep Clip is a tool for collecting and organizing text snippets with full respect for your privacy. Here's how your data is handled:</p>
-          <ul class="prose" style="margin-top:0.75rem">
-            <li>All clips, tags, and context you save are stored locally on your device in a private database.</li>
-            <li>The app does not collect personal data or send your clips to any server.</li>
-            <li>Keep Clip includes no advertising, analytics, or third-party tracking libraries.</li>
-            <li>The app requests internet access only to fetch metadata (like page titles) for links you choose to save.</li>
-            <li>Your data stays on your device unless you choose to share or export it.</li>
-            <li>Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
-          </ul>
-          <p class="card__text card__text--base" style="margin-top:0.75rem">Keep Clip is designed to give you full control over your saved text, with minimal permissions and no external data sharing.</p>
-        </div>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Keep Clip — Privacy Policy</h1>
       </div>
-    </section>
+      <div class="prose-card">
+        <p class="lead">Keep Clip is a tool for collecting and organizing text snippets with full respect for your privacy. Here's how your data is handled:</p>
+        <ul>
+          <li>All clips, tags, and context you save are stored locally on your device in a private database.</li>
+          <li>The app does not collect personal data or send your clips to any server.</li>
+          <li>Keep Clip includes no advertising, analytics, or third-party tracking libraries.</li>
+          <li>The app requests internet access only to fetch metadata (like page titles) for links you choose to save.</li>
+          <li>Your data stays on your device unless you choose to share or export it.</li>
+          <li>Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
+        </ul>
+        <p>Keep Clip is designed to give you full control over your saved text, with minimal permissions and no external data sharing.</p>
+      </div>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -109,7 +117,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -6,7 +6,7 @@
   <title>Privacy — Ulix</title>
   <meta name="description" content="Ulix privacy overview and links to app-specific policies." />
   <link rel="canonical" href="https://ulix.app/privacy.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
@@ -22,13 +22,22 @@
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -48,11 +57,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -75,41 +85,32 @@
   </div>
 
   <main id="main">
-    <section class="page-hero">
-      <div class="container">
-        <h1 class="page-hero__title">Privacy at Ulix</h1>
-        <p class="page-hero__subtitle">
-          Ulix is privacy-first. We don’t run ads or sell personal data, and many apps do not require an account.
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Privacy at Ulix</h1>
+        <p class="doc-hero__lede">Ulix is privacy-first. We don’t run ads or sell personal data, and many apps do not require an account.
           Some apps may use limited third-party services for core functionality or reliability diagnostics as described in each app-specific policy.
-          For details, see the app-specific policies below.
-        </p>
+          For details, see the app-specific policies below.</p>
       </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <div class="card">
-          <h2 class="card__title card__title--lg">App-Specific Privacy Policies</h2>
-          <ul class="prose" style="margin-top:0.75rem">
-            <li><a class="underline-accent" href="./gutenprivacy.html">Guten Privacy Policy</a></li>
-            <li><a class="underline-accent" href="./shelfscanprivacy.html">Shelf Scan Privacy Policy</a></li>
-            <li><a class="underline-accent" href="./keepclipprivacypolicy.html">Keep Clip Privacy Policy</a></li>
-            <li><a class="underline-accent" href="./trackanalysisprivacy.html">Track Analysis Privacy Policy</a></li>
-          </ul>
-        </div>
+      <div class="prose-card">
+        <h2>App-Specific Privacy Policies</h2>
+        <ul>
+          <li><a href="./gutenprivacy.html">Guten Privacy Policy</a></li>
+          <li><a href="./shelfscanprivacy.html">Shelf Scan Privacy Policy</a></li>
+          <li><a href="./keepclipprivacypolicy.html">Keep Clip Privacy Policy</a></li>
+          <li><a href="./trackanalysisprivacy.html">Track Analysis Privacy Policy</a></li>
+        </ul>
       </div>
-    </section>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -128,7 +129,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/shelfscanprivacy.html
+++ b/shelfscanprivacy.html
@@ -6,17 +6,26 @@
   <title>Shelf Scan — Privacy — Ulix</title>
   <meta name="description" content="How Shelf Scan handles your data: local only, no accounts, no analytics, no advertising." />
   <link rel="canonical" href="https://ulix.app/shelfscanprivacy.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -36,11 +45,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -63,34 +73,32 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg section--bg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Shelf Scan — Privacy</h1>
-        <div class="card" style="margin-top:1.5rem">
-          <p class="card__text card__text--base">Shelf Scan is built to help you search your shelves without compromising your privacy. Here's how your data is handled:</p>
-          <ul class="prose" style="margin-top:0.75rem">
-            <li>Captured images and recognized text are saved locally on your device in the app’s private storage.</li>
-            <li>No personal data is collected or transmitted. The app functions entirely offline.</li>
-            <li>There are no analytics, advertising, or third-party integrations.</li>
-            <li>You may choose to export or share your saved library using Android’s standard share features. This is completely optional and controlled by you.</li>
-            <li>The app requests access to your camera (to take photos for OCR) and uses vibration (for haptic feedback when scanning).</li>
-            <li>Your data stays on your device unless you decide to share it. Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
-          </ul>
-          <p class="card__text card__text--base" style="margin-top:0.75rem">Shelf Scan is designed to work powerfully without ever needing an internet connection.</p>
-        </div>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Shelf Scan — Privacy</h1>
       </div>
-    </section>
+      <div class="prose-card">
+        <p class="lead">Shelf Scan is built to help you search your shelves without compromising your privacy. Here's how your data is handled:</p>
+        <ul>
+          <li>Captured images and recognized text are saved locally on your device in the app’s private storage.</li>
+          <li>No personal data is collected or transmitted. The app functions entirely offline.</li>
+          <li>There are no analytics, advertising, or third-party integrations.</li>
+          <li>You may choose to export or share your saved library using Android’s standard share features. This is completely optional and controlled by you.</li>
+          <li>The app requests access to your camera (to take photos for OCR) and uses vibration (for haptic feedback when scanning).</li>
+          <li>Your data stays on your device unless you decide to share it. Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
+        </ul>
+        <p>Shelf Scan is designed to work powerfully without ever needing an internet connection.</p>
+      </div>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -109,7 +117,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/trackanalysisprivacy.html
+++ b/trackanalysisprivacy.html
@@ -6,17 +6,26 @@
   <title>Track Analysis — Privacy — Ulix</title>
   <meta name="description" content="How Track Analysis handles your data: local only, no accounts, no analytics, no advertising." />
   <link rel="canonical" href="https://ulix.app/trackanalysisprivacy.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -36,11 +45,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -63,34 +73,32 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg section--bg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Track Analysis — Privacy Policy</h1>
-        <div class="card" style="margin-top:1.5rem">
-          <p class="card__text card__text--base">Track Analysis is a personal tracking app designed with privacy in mind. Here's how your data is handled:</p>
-          <ul class="prose" style="margin-top:0.75rem">
-            <li>All data you enter—such as event type, details, and timestamps—is stored locally on your device.</li>
-            <li>No data is collected, transmitted, or stored by us.</li>
-            <li>The app includes no advertising, no analytics, and no third-party integrations.</li>
-            <li>The only optional export is a CSV file saved in your app’s private storage. You may share it manually using Android's standard sharing options.</li>
-            <li>The app does not request access to your location, contacts, network, or other device features.</li>
-            <li>A disclaimer in the app reminds users that it is for personal use only and is not medical advice.</li>
-            <li>You remain in full control of your data. Nothing leaves your device unless you choose to export and share it. Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
-          </ul>
-        </div>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Track Analysis — Privacy Policy</h1>
       </div>
-    </section>
+      <div class="prose-card">
+        <p class="lead">Track Analysis is a personal tracking app designed with privacy in mind. Here's how your data is handled:</p>
+        <ul>
+          <li>All data you enter—such as event type, details, and timestamps—is stored locally on your device.</li>
+          <li>No data is collected, transmitted, or stored by us.</li>
+          <li>The app includes no advertising, no analytics, and no third-party integrations.</li>
+          <li>The only optional export is a CSV file saved in your app’s private storage. You may share it manually using Android's standard sharing options.</li>
+          <li>The app does not request access to your location, contacts, network, or other device features.</li>
+          <li>A disclaimer in the app reminds users that it is for personal use only and is not medical advice.</li>
+          <li>You remain in full control of your data. Nothing leaves your device unless you choose to export and share it. Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
+        </ul>
+      </div>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -109,7 +117,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Restyles all five privacy pages onto the homepage's warm-dark editorial design system, while keeping the card look from the old privacy pages — reimagined as a dark "prose card."

## Changes
- **New `.prose-card` + `.doc` / `.doc-hero` primitives** in `assets/home.css` — the light theme's shadowed `.card`, re-imagined for the warm-dark palette (lifted, rounded, bordered, soft shadow) with readable dark-theme prose (serif lead + section headings, Geist body, blue accent bullets and links). Reusable for terms/support later.
- **Rebuilt 5 privacy pages** on the shared `.home-page` system with the homepage header/footer/fonts:
  - `privacy.html` (index), `gutenprivacy.html`, `shelfscanprivacy.html`, `keepclipprivacypolicy.html`, `trackanalysisprivacy.html`

## Text fidelity
Policy copy was **not** retyped — the text nodes were extracted from the originals and only the presentational markup was swapped. Verified per page that the `<main>` text and every link `href` are byte-identical to the originals.

Follows the same approach as the merged apps.html restyle (shared `assets/home.css`).

https://claude.ai/code/session_01CDh8MWTgTNJa5YXx3GvKwg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDh8MWTgTNJa5YXx3GvKwg)_