### PR TITLE
Restyle Contact and Support pages to homepage style

### DIFF
--- a/assets/home.css
+++ b/assets/home.css
@@ -538,3 +538,46 @@
 @media (max-width: 760px) {
   .home-page .doc { padding: 40px 18px 64px; }
 }
+
+/* ---------- Forms inside the prose card (contact / support) ---------- */
+.home-page .form { display: grid; gap: 18px; }
+.home-page .form-field { display: grid; gap: 8px; }
+.home-page .form-label {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--fg);
+}
+.home-page .form-input,
+.home-page .form-textarea,
+.home-page .form-select {
+  width: 100%;
+  font-family: var(--sans);
+  font-size: 15px;
+  color: var(--fg);
+  background: rgba(255,255,255,0.035);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+.home-page .form-input::placeholder,
+.home-page .form-textarea::placeholder { color: var(--subtle); }
+.home-page .form-input:focus,
+.home-page .form-textarea:focus,
+.home-page .form-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(91,163,245,0.18);
+}
+.home-page .form-textarea { min-height: 150px; resize: vertical; }
+.home-page .form-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 40px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none' stroke='%23F4EFE6' stroke-opacity='0.5' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M1 1.5l5 5 5-5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+}
+.home-page .form-note { font-size: 12.5px; line-height: 1.55; color: var(--subtle); }
+.home-page .form-footer-note { font-size: 14px; line-height: 1.55; color: var(--muted); }

--- a/contact.html
+++ b/contact.html
@@ -6,7 +6,7 @@
   <title>Contact — Ulix</title>
   <meta name="description" content="Get in touch with Ulix. For app-specific help, visit Support." />
   <link rel="canonical" href="https://ulix.app/contact.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
@@ -22,13 +22,22 @@
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -48,11 +57,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -75,60 +85,58 @@
   </div>
 
   <main id="main">
-    <section class="section section--bg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Contact</h1>
-        <div class="card" style="margin-top:1rem">
-          <form class="form" action="https://formsubmit.co/hello@ulix.app" method="POST" novalidate>
-
-            <div class="form-field">
-              <label class="form-label" for="name">Name</label>
-              <input id="name" name="name" class="form-input" placeholder="Jane Doe" autocomplete="name" required />
-            </div>
-
-            <div class="form-field">
-              <label class="form-label" for="email">Email</label>
-              <input id="email" name="email" type="email" class="form-input" placeholder="you@example.com" autocomplete="email" required />
-            </div>
-
-            <!-- Honeypots (off-screen so bots still fill them, humans don't see them) -->
-            <input type="text" id="website" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
-            <input type="text" name="_honey" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
-
-            <div class="form-field">
-              <label class="form-label" for="message">Message</label>
-              <textarea id="message" name="message" rows="6" class="form-textarea" placeholder="How can we help?" required></textarea>
-            </div>
-
-            <input type="hidden" name="_subject" value="Ulix Contact Form" />
-            <input type="hidden" name="_next" value="https://ulix.app/thanks.html" />
-
-            <div>
-              <button class="btn btn--primary" type="submit">Send</button>
-            </div>
-
-            <div class="form-footer-note">
-              Need help with a specific app? <a href="./support.html" class="underline-accent">Visit Support →</a>
-            </div>
-            <div class="form-note">
-              We don’t accept unsolicited ideas or proposals. By sending feedback, you agree to our
-              <a href="./terms.html" class="underline-accent">Terms of Service</a>.
-            </div>
-          </form>
-        </div>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Contact</h1>
       </div>
-    </section>
+      <div class="prose-card">
+        <form class="form" action="https://formsubmit.co/hello@ulix.app" method="POST" novalidate>
+
+          <div class="form-field">
+            <label class="form-label" for="name">Name</label>
+            <input id="name" name="name" class="form-input" placeholder="Jane Doe" autocomplete="name" required />
+          </div>
+
+          <div class="form-field">
+            <label class="form-label" for="email">Email</label>
+            <input id="email" name="email" type="email" class="form-input" placeholder="you@example.com" autocomplete="email" required />
+          </div>
+
+          <!-- Honeypots (off-screen so bots still fill them, humans don't see them) -->
+          <input type="text" id="website" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
+          <input type="text" name="_honey" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
+
+          <div class="form-field">
+            <label class="form-label" for="message">Message</label>
+            <textarea id="message" name="message" rows="6" class="form-textarea" placeholder="How can we help?" required></textarea>
+          </div>
+
+          <input type="hidden" name="_subject" value="Ulix Contact Form" />
+          <input type="hidden" name="_next" value="https://ulix.app/thanks.html" />
+
+          <div>
+            <button class="btn btn--primary" type="submit">Send</button>
+          </div>
+
+          <div class="form-footer-note">
+            Need help with a specific app? <a href="./support.html">Visit Support →</a>
+          </div>
+          <div class="form-note">
+            We don’t accept unsolicited ideas or proposals. By sending feedback, you agree to our
+            <a href="./terms.html">Terms of Service</a>.
+          </div>
+        </form>
+      </div>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -147,7 +155,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/support.html
+++ b/support.html
@@ -6,7 +6,7 @@
   <title>Support — Ulix</title>
   <meta name="description" content="Get help with a Ulix app. Tell us what’s happening and we’ll get back to you." />
   <link rel="canonical" href="https://ulix.app/support.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
@@ -22,13 +22,22 @@
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -48,11 +57,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -75,73 +85,68 @@
   </div>
 
   <main id="main">
-    <section class="section section--bg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Support</h1>
-        <div class="card" style="margin-top:1.5rem">
-          <p class="card__text card__text--base" style="margin-top:0;margin-bottom:1rem">
-            Use this form to reach Ulix support. We’ll get back to you at the email address you provide.
-          </p>
-
-          <form class="form" action="https://formsubmit.co/support@ulix.app" method="POST" novalidate>
-
-            <div class="form-field">
-              <label class="form-label" for="name">Name</label>
-              <input id="name" name="name" class="form-input" placeholder="Jane Doe" autocomplete="name" required />
-            </div>
-
-            <div class="form-field">
-              <label class="form-label" for="email">Email</label>
-              <input id="email" name="email" type="email" class="form-input" placeholder="you@example.com" autocomplete="email" required />
-            </div>
-
-            <input type="text" id="website" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
-            <input type="text" name="_honey" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
-
-            <div class="form-field">
-              <label class="form-label" for="app">Which app?</label>
-              <select id="app" name="app" class="form-select">
-                <option>General</option>
-                <option>Shelf Scan</option>
-                <option>Keep Clip</option>
-                <option>Guten</option>
-                <option>Loan It</option>
-                <option>Track Analysis</option>
-                <option>Curious Air</option>
-              </select>
-            </div>
-
-            <div class="form-field">
-              <label class="form-label" for="issue">Describe the issue</label>
-              <textarea id="issue" name="issue" rows="6" class="form-textarea" placeholder="What happened? Steps to reproduce? Device/OS version?" required></textarea>
-            </div>
-
-            <input type="hidden" name="_subject" value="Ulix Support Request" />
-            <input type="hidden" name="_next" value="https://ulix.app/thanks.html" />
-
-            <div>
-              <button class="btn btn--primary" type="submit">Send</button>
-            </div>
-
-            <div class="form-note">
-              We don’t accept unsolicited ideas or proposals. By sending feedback, you agree to our
-              <a class="underline-accent" href="./terms.html">Terms of Service</a>.
-            </div>
-          </form>
-        </div>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Support</h1>
       </div>
-    </section>
+      <div class="prose-card">
+        <p class="lead">Use this form to reach Ulix support. We’ll get back to you at the email address you provide.</p>
+        <form class="form" action="https://formsubmit.co/support@ulix.app" method="POST" novalidate>
+
+          <div class="form-field">
+            <label class="form-label" for="name">Name</label>
+            <input id="name" name="name" class="form-input" placeholder="Jane Doe" autocomplete="name" required />
+          </div>
+
+          <div class="form-field">
+            <label class="form-label" for="email">Email</label>
+            <input id="email" name="email" type="email" class="form-input" placeholder="you@example.com" autocomplete="email" required />
+          </div>
+
+          <input type="text" id="website" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
+          <input type="text" name="_honey" autocomplete="off" tabindex="-1" aria-hidden="true" class="honeypot" />
+
+          <div class="form-field">
+            <label class="form-label" for="app">Which app?</label>
+            <select id="app" name="app" class="form-select">
+              <option>General</option>
+              <option>Shelf Scan</option>
+              <option>Keep Clip</option>
+              <option>Guten</option>
+              <option>Loan It</option>
+              <option>Track Analysis</option>
+              <option>Curious Air</option>
+            </select>
+          </div>
+
+          <div class="form-field">
+            <label class="form-label" for="issue">Describe the issue</label>
+            <textarea id="issue" name="issue" rows="6" class="form-textarea" placeholder="What happened? Steps to reproduce? Device/OS version?" required></textarea>
+          </div>
+
+          <input type="hidden" name="_subject" value="Ulix Support Request" />
+          <input type="hidden" name="_next" value="https://ulix.app/thanks.html" />
+
+          <div>
+            <button class="btn btn--primary" type="submit">Send</button>
+          </div>
+
+          <div class="form-note">
+            We don’t accept unsolicited ideas or proposals. By sending feedback, you agree to our
+            <a href="./terms.html">Terms of Service</a>.
+          </div>
+        </form>
+      </div>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -160,7 +165,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Restyles the Contact and Support pages onto the homepage's warm-dark editorial design system, wrapping each form in the same "prose card" used on the privacy pages.

## Changes
- **Dark-theme form styling** added to `assets/home.css` (`.form`, labels, inputs, textarea, and a custom-chevron `<select>`, with an accent focus ring) so the forms read well on the dark surface.
- **Rebuilt `contact.html` and `support.html`** on the shared `.home-page` system with the homepage header/footer/fonts; each form now sits inside the `.prose-card`. Support's intro sentence becomes the card's serif lead.

## Form fidelity
The FormSubmit forms are **preserved verbatim** — endpoints (`hello@ulix.app` / `support@ulix.app`), `method="POST"`, every field name, the honeypots, the hidden `_subject` / `_next`, and the Support app `<select>` with all 7 options. Verified that the only difference from the originals is dropping the light-theme `underline-accent` class (the note links now inherit the card's link style). Visible text and all `href`s were checked identical.

Follows the same approach as the merged apps.html and privacy restyles (shared `assets/home.css`).

https://claude.ai/code/session_01CDh8MWTgTNJa5YXx3GvKwg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDh8MWTgTNJa5YXx3GvKwg)_