### PR TITLE
Restyle About, Blog, Terms, Thanks, and 404 to homepage style

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,18 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Page not found — Ulix</title>
   <meta name="description" content="The page you were looking for doesn’t exist. Head back to Ulix." />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
   <meta name="robots" content="noindex" />
   <link rel="icon" href="/icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="/icons/favicon.png" />
   <link rel="stylesheet" href="/assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="/assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="/assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="/" class="site-brand">
         <img src="/icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -36,11 +45,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="/apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="/apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -63,31 +73,25 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg">
-      <div class="container text-center">
-        <div class="card card--lg" style="display:inline-block;max-width:32rem">
-          <h1 style="font-size:2rem;font-weight:600;color:var(--ulix-primary);margin-bottom:0.5rem">Page not found</h1>
-          <p class="card__text card__text--base" style="margin-bottom:1.5rem">
-            Sorry — we couldn’t find that page. Let’s get you back on course.
-          </p>
-          <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap">
-            <a href="/" class="btn btn--primary">Home</a>
-            <a href="/apps.html" class="btn btn--secondary">Apps</a>
-          </div>
+    <div class="doc doc--narrow">
+      <div class="prose-card prose-card--center">
+        <h1 class="status-title">Page not found</h1>
+        <p class="lead">Sorry — we couldn’t find that page. Let’s get you back on course.</p>
+        <div class="status-actions">
+          <a href="/" class="btn btn--primary">Home</a>
+          <a href="/apps.html" class="btn btn--secondary">Apps</a>
         </div>
       </div>
-    </section>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="/icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="/icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="/apps.html">Apps</a>
@@ -106,7 +110,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/about.html
+++ b/about.html
@@ -6,7 +6,7 @@
   <title>About — Ulix</title>
   <meta name="description" content="Why Ulix: privacy-first design, focused tools, built on products not data." />
   <link rel="canonical" href="https://ulix.app/about.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
@@ -22,13 +22,22 @@
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -37,7 +46,7 @@
         <a href="./index.html" class="site-nav__link">Home</a>
         <a href="./apps.html" class="site-nav__link">Apps</a>
         <a href="./blog.html" class="site-nav__link">Blog</a>
-        <a href="./about.html" class="site-nav__link" aria-current="page">About</a>
+        <a href="./about.html" class="site-nav__link">About</a>
         <a href="./contact.html" class="site-nav__link">Contact</a>
       </nav>
       <div class="site-header__actions">
@@ -48,11 +57,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -75,62 +85,42 @@
   </div>
 
   <main id="main">
-    <section class="page-hero">
-      <div class="container">
-        <h1 class="page-hero__title">About Ulix</h1>
-        <p class="page-hero__subtitle">Precision Tools for Modern Odysseys</p>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">About Ulix</h1>
+        <p class="doc-hero__lede">Precision Tools for Modern Odysseys</p>
       </div>
-    </section>
-
-    <section class="section section--bg">
-      <div class="container prose">
-        <div class="stack stack--lg">
-          <div class="card card--lg">
-            <h3 class="card__title card__title--lg">Privacy First</h3>
-            <p class="card__text card__text--base">
-              We believe your data should remain yours. That’s why every Ulix app is built local-first: they run on your device, work offline, and don’t depend on cloud services.
-              We don’t run ads, track behavior, or ask for intrusive permissions. If an account isn’t essential, we don’t require one. Privacy isn’t an extra feature; it’s one of the foundations of what we do.
-            </p>
-          </div>
-
-          <div class="card card--lg">
-            <h3 class="card__title card__title--lg">Curated by Design</h3>
-            <p class="card__text card__text--base">
-              Ulix apps are not generic utilities. They are shaped by our founder’s particular aesthetic vision. If you share that vision, you’ll feel at home.
-              We design for a specific taste: apps that feel good to use, not because they’re flashy, but because they are intuitive, elegant, and intentional.
-            </p>
-          </div>
-
-          <div class="card card--lg">
-            <h3 class="card__title card__title--lg">Focused Tools</h3>
-            <p class="card__text card__text--base">
-              Software should help you get back to your real life, not trap you on a screen. Each Ulix app has a clear purpose and a clean interface.
-              No bloat, no noisy notifications, no attention-grabs. Ulix apps are built to be lightweight companions that extend your abilities and then step aside, so you can focus on what actually matters.
-            </p>
-          </div>
-
-          <div class="card card--lg">
-            <h3 class="card__title card__title--lg">Built on Products, Not Data</h3>
-            <p class="card__text card__text--base">
-              Most modern apps are free because you’re the product. Ulix takes the harder road: we sell our apps, not our customers.
+      <div class="prose-card">
+        <h2>Privacy First</h2>
+        <p>We believe your data should remain yours. That’s why every Ulix app is built local-first: they run on your device, work offline, and don’t depend on cloud services.
+              We don’t run ads, track behavior, or ask for intrusive permissions. If an account isn’t essential, we don’t require one. Privacy isn’t an extra feature; it’s one of the foundations of what we do.</p>
+      </div>
+      <div class="prose-card">
+        <h2>Curated by Design</h2>
+        <p>Ulix apps are not generic utilities. They are shaped by our founder’s particular aesthetic vision. If you share that vision, you’ll feel at home.
+              We design for a specific taste: apps that feel good to use, not because they’re flashy, but because they are intuitive, elegant, and intentional.</p>
+      </div>
+      <div class="prose-card">
+        <h2>Focused Tools</h2>
+        <p>Software should help you get back to your real life, not trap you on a screen. Each Ulix app has a clear purpose and a clean interface.
+              No bloat, no noisy notifications, no attention-grabs. Ulix apps are built to be lightweight companions that extend your abilities and then step aside, so you can focus on what actually matters.</p>
+      </div>
+      <div class="prose-card">
+        <h2>Built on Products, Not Data</h2>
+        <p>Most modern apps are free because you’re the product. Ulix takes the harder road: we sell our apps, not our customers.
               That choice costs us revenue opportunities, but it keeps us aligned with you. Our business model is simple: you pay us for good tools, and we build good tools.
-              No hidden agendas, no monetizing of you.
-            </p>
-          </div>
-        </div>
+              No hidden agendas, no monetizing of you.</p>
       </div>
-    </section>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -149,7 +139,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/assets/home.css
+++ b/assets/home.css
@@ -528,12 +528,12 @@
   border-radius: 50%;
   background: var(--accent);
 }
-.home-page .prose-card a {
+.home-page .prose-card a:not(.btn) {
   color: var(--accent);
   text-decoration: none;
   border-bottom: 1px solid rgba(91,163,245,0.45);
 }
-.home-page .prose-card a:hover { border-bottom-color: var(--accent); }
+.home-page .prose-card a:not(.btn):hover { border-bottom-color: var(--accent); }
 
 @media (max-width: 760px) {
   .home-page .doc { padding: 40px 18px 64px; }
@@ -581,3 +581,34 @@
 }
 .home-page .form-note { font-size: 12.5px; line-height: 1.55; color: var(--subtle); }
 .home-page .form-footer-note { font-size: 14px; line-height: 1.55; color: var(--muted); }
+
+/* ---------- Stacked prose cards (about page values) ---------- */
+.home-page .prose-card + .prose-card { margin-top: 22px; }
+
+/* ---------- Reveal list (terms contact section) ---------- */
+.home-page .prose-card .reveal-list {
+  margin-top: 14px;
+  font-family: var(--sans);
+  font-size: 15.5px;
+  line-height: 1.75;
+  color: var(--muted);
+}
+
+/* ---------- Centered status pages (thanks / 404) ---------- */
+.home-page .doc--narrow { max-width: 560px; }
+.home-page .prose-card--center { text-align: center; }
+.home-page .prose-card--center .status-title {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: clamp(30px, 5vw, 44px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.home-page .status-actions {
+  margin-top: 26px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/blog.html
+++ b/blog.html
@@ -6,7 +6,7 @@
   <title>Blog — Ulix</title>
   <meta name="description" content="Signals from Ulix — updates on new apps, new features, and the occasional idea on tools that serve." />
   <link rel="canonical" href="https://ulix.app/blog.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
@@ -22,13 +22,22 @@
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -48,11 +57,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -75,32 +85,25 @@
   </div>
 
   <main id="main">
-    <section class="page-hero">
-      <div class="container">
-        <h1 class="page-hero__title">Signals from Ulix</h1>
-        <p class="page-hero__subtitle">New apps, new updates, and the occasional interesting idea for those who believe tools should serve.</p>
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Signals from Ulix</h1>
+        <p class="doc-hero__lede">New apps, new updates, and the occasional interesting idea for those who believe tools should serve.</p>
       </div>
-    </section>
-
-    <section class="section section--bg">
-      <div class="container">
-        <div class="card card--lg" style="max-width:36rem">
-          <h2 class="card__title card__title--lg">Coming Soon</h2>
-          <p class="card__text card__text--base">Sign up for our email list below to receive notifications of new posts.</p>
-        </div>
+      <div class="prose-card">
+        <h2>Coming Soon</h2>
+        <p>Sign up for our email list below to receive notifications of new posts.</p>
       </div>
-    </section>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -119,7 +122,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/terms.html
+++ b/terms.html
@@ -6,7 +6,7 @@
   <title>Terms of Service — Ulix</title>
   <meta name="description" content="Ulix Terms of Service: license, purchases, privacy, liability, and contact information." />
   <link rel="canonical" href="https://ulix.app/terms.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
@@ -22,13 +22,22 @@
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -48,11 +57,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -75,119 +85,67 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg">
-      <div class="container">
-        <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary)">Terms of Service</h1>
-        <div class="meta-date">Last updated: 2025-08-16</div>
-
-        <div class="stack" style="margin-top:1.5rem">
-
-          <div class="card">
-            <h2 class="card__title">Plain-English summary</h2>
-            <ul class="prose" style="margin-top:0.5rem">
-              <li>You can use Ulix apps under a personal, non-transferable license.</li>
-              <li>Purchases and refunds are handled by the app store (e.g., Google Play).</li>
-              <li>We own the Ulix site/app content and trademarks; all rights reserved.</li>
-              <li>We don’t accept unsolicited ideas; if you send them, we may use similar ideas.</li>
-              <li>We provide the software "as is"; our liability is limited.</li>
-              <li>We respect privacy; see the Privacy Policy for details.</li>
-              <li>Arkansas law applies; venue is Washington County (Springdale), USA.</li>
-            </ul>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Acceptance of Terms</h3>
-            <p class="card__text">These Terms are an agreement between you and Ulix LLC ("Ulix"). By accessing the website or using any Ulix application (the "Services"), you agree to these Terms. If you do not agree, do not use the Services. We may update these Terms prospectively; changes are indicated by the date above.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Eligibility</h3>
-            <p class="card__text">You must be able to form a binding contract in your jurisdiction. The Services are intended for personal use. Where applicable, you are responsible for compliance with local laws.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">License and Acceptable Use</h3>
-            <p class="card__text">Subject to these Terms, Ulix grants you a limited, non-exclusive, non-transferable, revocable license to install and use our apps for personal, non-commercial purposes. You agree not to: (a) reverse engineer except as permitted by law; (b) sell or sublicense the Services; (c) access the Services to build a competing product; (d) disrupt or interfere with the Services; or (e) use the Services for unlawful purposes.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Purchases and Refunds</h3>
-            <p class="card__text">If you purchase an Ulix app through a platform (e.g., Google Play), the platform’s terms govern billing, taxes, and refunds. Please refer to the store’s policies for refund eligibility and timelines. If you have an issue, please use our <a href="support.html" class="underline-accent">Support form</a>. You can also <button class="underline-accent" style="background:none;border:0;padding:0;color:inherit" data-reveal-email>reveal our support email</button>.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">User Content</h3>
-            <p class="card__text">Ulix does not host accounts for most apps and aims for local-first processing. If you submit content to us (e.g., via support email), you retain ownership of your content. You grant Ulix a limited license to use that content solely to provide support and operate or improve the Services.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Intellectual Property</h3>
-            <p class="card__text">All rights, title, and interest in and to the Services—including software, text, graphics, UI, and design—are owned by Ulix or its licensors and are protected by copyright, trademark, and other laws. "ULIX" and related logos are trademarks of Ulix LLC. Third-party names and marks are the property of their respective owners.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Feedback and Unsolicited Ideas</h3>
-            <p class="card__text">Ulix does not accept or consider unsolicited ideas or proposals. If you nevertheless send any, you agree they are non-confidential and non-proprietary, we have no obligation to review or compensate you, and Ulix may already be developing similar products or features.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Privacy</h3>
-            <p class="card__text">Your privacy matters. Our apps are designed to minimize data collection and favor on-device processing. Please review our Privacy Policy for details on what we collect (if anything) and why.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Third-Party Services and Links</h3>
-            <p class="card__text">The Services may reference third-party sites, stores, libraries, or services. Ulix is not responsible for third-party content, policies, or practices. Your use of third-party services is governed by their terms and policies.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Disclaimers</h3>
-            <p class="card__text">TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. Ulix does not warrant that the Services will be uninterrupted, secure, or error-free.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Limitation of Liability</h3>
-            <p class="card__text">TO THE MAXIMUM EXTENT PERMITTED BY LAW, ULIX AND ITS AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, AND PARTNERS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, DATA, OR GOODWILL, ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICES. ULIX’S TOTAL LIABILITY FOR ANY CLAIMS RELATING TO THE SERVICES IS LIMITED TO THE AMOUNTS YOU PAID (IF ANY) FOR THE APPLICABLE APP IN THE TWELVE (12) MONTHS BEFORE THE EVENT GIVING RISE TO LIABILITY.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Indemnification</h3>
-            <p class="card__text">You agree to defend, indemnify, and hold harmless Ulix from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys’ fees) arising out of or related to (a) your use of the Services; (b) your violation of these Terms; or (c) your violation of any rights of another person or entity.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Governing Law and Venue</h3>
-            <p class="card__text">These Terms are governed by the laws of the State of Arkansas, U.S.A., without regard to conflict-of-laws principles. You and Ulix agree to the exclusive jurisdiction and venue of the state and federal courts located in Washington County, Arkansas (Springdale).</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Miscellaneous</h3>
-            <p class="card__text">If any provision of these Terms is found unenforceable, it will be enforced to the maximum extent permissible and the remaining provisions will remain in full force. These Terms constitute the entire agreement between you and Ulix regarding the Services. We may assign these Terms; you may not assign them without our consent. Headings are for convenience only.</p>
-          </div>
-
-          <div class="card">
-            <h3 class="card__title">Contact</h3>
-            <div class="card__text">
-              <div>Mailing address: <button class="underline-accent" style="background:none;border:0;padding:0;color:inherit" data-reveal-address>Reveal mailing address</button></div>
-              <div style="margin-top:0.25rem">Email: <button class="underline-accent" style="background:none;border:0;padding:0;color:inherit" data-reveal-email>Reveal email</button></div>
-              <div style="margin-top:0.5rem"><a href="support.html" class="underline-accent">Open Support form →</a></div>
-            </div>
-          </div>
-
+    <div class="doc">
+      <div class="doc-hero">
+        <h1 class="doc-hero__title">Terms of Service</h1>
+        <div class="doc-hero__meta">Last updated: 2025-08-16</div>
+      </div>
+      <div class="prose-card">
+        <h2>Plain-English summary</h2>
+        <ul>
+          <li>You can use Ulix apps under a personal, non-transferable license.</li>
+          <li>Purchases and refunds are handled by the app store (e.g., Google Play).</li>
+          <li>We own the Ulix site/app content and trademarks; all rights reserved.</li>
+          <li>We don’t accept unsolicited ideas; if you send them, we may use similar ideas.</li>
+          <li>We provide the software "as is"; our liability is limited.</li>
+          <li>We respect privacy; see the Privacy Policy for details.</li>
+          <li>Arkansas law applies; venue is Washington County (Springdale), USA.</li>
+        </ul>
+        <h2>Acceptance of Terms</h2>
+        <p>These Terms are an agreement between you and Ulix LLC ("Ulix"). By accessing the website or using any Ulix application (the "Services"), you agree to these Terms. If you do not agree, do not use the Services. We may update these Terms prospectively; changes are indicated by the date above.</p>
+        <h2>Eligibility</h2>
+        <p>You must be able to form a binding contract in your jurisdiction. The Services are intended for personal use. Where applicable, you are responsible for compliance with local laws.</p>
+        <h2>License and Acceptable Use</h2>
+        <p>Subject to these Terms, Ulix grants you a limited, non-exclusive, non-transferable, revocable license to install and use our apps for personal, non-commercial purposes. You agree not to: (a) reverse engineer except as permitted by law; (b) sell or sublicense the Services; (c) access the Services to build a competing product; (d) disrupt or interfere with the Services; or (e) use the Services for unlawful purposes.</p>
+        <h2>Purchases and Refunds</h2>
+        <p>If you purchase an Ulix app through a platform (e.g., Google Play), the platform’s terms govern billing, taxes, and refunds. Please refer to the store’s policies for refund eligibility and timelines. If you have an issue, please use our <a href="support.html">Support form</a>. You can also <button style="background:none;border:0;padding:0;color:var(--accent);font:inherit;cursor:pointer;text-decoration:underline" data-reveal-email>reveal our support email</button>.</p>
+        <h2>User Content</h2>
+        <p>Ulix does not host accounts for most apps and aims for local-first processing. If you submit content to us (e.g., via support email), you retain ownership of your content. You grant Ulix a limited license to use that content solely to provide support and operate or improve the Services.</p>
+        <h2>Intellectual Property</h2>
+        <p>All rights, title, and interest in and to the Services—including software, text, graphics, UI, and design—are owned by Ulix or its licensors and are protected by copyright, trademark, and other laws. "ULIX" and related logos are trademarks of Ulix LLC. Third-party names and marks are the property of their respective owners.</p>
+        <h2>Feedback and Unsolicited Ideas</h2>
+        <p>Ulix does not accept or consider unsolicited ideas or proposals. If you nevertheless send any, you agree they are non-confidential and non-proprietary, we have no obligation to review or compensate you, and Ulix may already be developing similar products or features.</p>
+        <h2>Privacy</h2>
+        <p>Your privacy matters. Our apps are designed to minimize data collection and favor on-device processing. Please review our Privacy Policy for details on what we collect (if anything) and why.</p>
+        <h2>Third-Party Services and Links</h2>
+        <p>The Services may reference third-party sites, stores, libraries, or services. Ulix is not responsible for third-party content, policies, or practices. Your use of third-party services is governed by their terms and policies.</p>
+        <h2>Disclaimers</h2>
+        <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. Ulix does not warrant that the Services will be uninterrupted, secure, or error-free.</p>
+        <h2>Limitation of Liability</h2>
+        <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, ULIX AND ITS AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, AND PARTNERS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, DATA, OR GOODWILL, ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICES. ULIX’S TOTAL LIABILITY FOR ANY CLAIMS RELATING TO THE SERVICES IS LIMITED TO THE AMOUNTS YOU PAID (IF ANY) FOR THE APPLICABLE APP IN THE TWELVE (12) MONTHS BEFORE THE EVENT GIVING RISE TO LIABILITY.</p>
+        <h2>Indemnification</h2>
+        <p>You agree to defend, indemnify, and hold harmless Ulix from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys’ fees) arising out of or related to (a) your use of the Services; (b) your violation of these Terms; or (c) your violation of any rights of another person or entity.</p>
+        <h2>Governing Law and Venue</h2>
+        <p>These Terms are governed by the laws of the State of Arkansas, U.S.A., without regard to conflict-of-laws principles. You and Ulix agree to the exclusive jurisdiction and venue of the state and federal courts located in Washington County, Arkansas (Springdale).</p>
+        <h2>Miscellaneous</h2>
+        <p>If any provision of these Terms is found unenforceable, it will be enforced to the maximum extent permissible and the remaining provisions will remain in full force. These Terms constitute the entire agreement between you and Ulix regarding the Services. We may assign these Terms; you may not assign them without our consent. Headings are for convenience only.</p>
+        <h2>Contact</h2>
+        <div class="reveal-list">
+          <div>Mailing address: <button style="background:none;border:0;padding:0;color:var(--accent);font:inherit;cursor:pointer;text-decoration:underline" data-reveal-address>Reveal mailing address</button></div>
+              <div style="margin-top:0.25rem">Email: <button style="background:none;border:0;padding:0;color:var(--accent);font:inherit;cursor:pointer;text-decoration:underline" data-reveal-email>Reveal email</button></div>
+              <div style="margin-top:0.5rem"><a href="support.html">Open Support form →</a></div>
         </div>
       </div>
-    </section>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -206,7 +164,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>

--- a/thanks.html
+++ b/thanks.html
@@ -6,19 +6,28 @@
   <title>Thanks — Ulix</title>
   <meta name="description" content="Your message has been sent. Thank you for reaching out to Ulix." />
   <link rel="canonical" href="https://ulix.app/thanks.html" />
-  <meta name="theme-color" content="#00142F" />
+  <meta name="theme-color" content="#0F0E0C" />
   <meta name="robots" content="noindex" />
 
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
   <link rel="stylesheet" href="./assets/ulix.css" />
+
+  <!-- Fonts: Geist (self-hosted) + Newsreader (display serif). Matches the homepage. -->
+  <link rel="preload" as="font" type="font/woff2" href="./assets/fonts/geist-latin.woff2" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
+  <!-- Shared warm-dark editorial design system (same as the homepage) -->
+  <link rel="stylesheet" href="./assets/home.css" />
 </head>
 
-<body>
+<body class="home-page">
   <a href="#main" class="skip-link">Skip to content</a>
 
+  <!-- Header (shared site chrome) -->
   <header class="site-header">
-    <div class="container site-header__inner">
+    <div class="container container--wide site-header__inner">
       <a href="./index.html" class="site-brand">
         <img src="./icons/favicon.png" alt="" class="site-brand__logo" />
         <span class="site-brand__name">ULIX</span>
@@ -38,11 +47,12 @@
             <line x1="4" y1="17" x2="20" y2="17"/>
           </svg>
         </button>
-        <a href="./apps.html" class="btn btn--primary btn--header">Explore Apps</a>
+        <a href="./apps.html" class="btn btn--primary btn--header">Browse all apps →</a>
       </div>
     </div>
   </header>
 
+  <!-- Mobile drawer -->
   <div id="u-mobile" class="drawer" role="dialog" aria-modal="true" aria-label="Menu" hidden>
     <div class="drawer__backdrop" data-close></div>
     <div class="drawer__panel">
@@ -65,28 +75,24 @@
   </div>
 
   <main id="main">
-    <section class="section section--lg">
-      <div class="container text-center">
-        <div class="card card--lg" style="display:inline-block">
-          <h1 style="font-size:1.875rem;font-weight:600;color:var(--ulix-primary);margin-bottom:1rem">Thank you!</h1>
-          <p class="card__text card__text--base" style="margin-bottom:1.5rem">
-            Your message has been sent successfully. We’ll review it and get back to you at the email you provided.
-          </p>
-          <a href="./index.html" class="btn btn--primary" style="padding:0.75rem 1.5rem">Back to Home</a>
+    <div class="doc doc--narrow">
+      <div class="prose-card prose-card--center">
+        <h1 class="status-title">Thank you!</h1>
+        <p class="lead">Your message has been sent successfully. We’ll review it and get back to you at the email you provided.</p>
+        <div class="status-actions">
+          <a href="./index.html" class="btn btn--primary">Back to Home</a>
         </div>
       </div>
-    </section>
+    </div>
   </main>
 
+  <!-- Footer (shared site chrome) -->
   <footer class="site-footer">
     <div class="container">
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/favicon.png" alt="" width="32" height="32" style="border-radius:0.5rem" />
-          <div>
-            <div class="site-footer__brand-name">ULIX</div>
-            <p class="site-footer__tag">Precision tools for modern odysseys.</p>
-          </div>
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>
@@ -105,7 +111,7 @@
               <button class="btn btn--secondary">Subscribe</button>
             </div>
           </form>
-          <div class="site-footer__copyright">© 2025 Ulix LLC. All rights reserved.</div>
+          <div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Moves the **remaining** pages onto the homepage's warm-dark editorial design system, completing the site-wide restyle (after apps, privacy, and contact/support).

## Pages
- **about.html** — the four value statements become stacked prose cards under the serif hero.
- **blog.html** — hero + a "Coming Soon" prose card.
- **terms.html** — the full policy rendered as one prose card with serif section headings and the bulleted summary. The **reveal email / mailing-address buttons and their inline script are preserved** (email still obfuscated via `String.fromCharCode`; verified the button still produces `mailto:support@ulix.app` after the restyle).
- **thanks.html** / **404.html** — centered status card with the message + action buttons. **404 keeps fully absolute paths** (it can be served at any URL depth) and its `robots: noindex`.

## CSS (assets/home.css)
- Stacked-card spacing, centered status layout, and a reveal-list style.
- Scoped the prose-card link rule to `a:not(.btn)` so in-card buttons (404/thanks CTAs) keep their button styling instead of inheriting link colors. (No effect on the already-merged pages — none have `<a class="btn">` inside a prose card.)

## Fidelity
All page text and links preserved verbatim (checked per page: normalized `<main>` text + every `href` identical to the originals; tags balanced). 404 verified styled over HTTP (absolute assets resolve; `body` background `#0F0E0C`).

https://claude.ai/code/session_01CDh8MWTgTNJa5YXx3GvKwg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDh8MWTgTNJa5YXx3GvKwg)_