### PR TITLE
Structured data: apps catalog ItemList, Guten schema upgrade, duplicates page WebPage node

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -13,11 +13,13 @@
   <meta property="og:title" content="Apps — Ulix" />
   <meta property="og:description" content="Privacy-first Android apps. No accounts, no ads, no tracking." />
   <meta property="og:url" content="https://ulix.app/apps.html" />
-  <meta property="og:image" content="https://ulix.app/icons/favicon.png" />
-  <meta name="twitter:card" content="summary" />
+  <meta property="og:image" content="https://ulix.app/assets/ulixsocialshare1.jpg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="633" />
+  <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Apps — Ulix" />
   <meta name="twitter:description" content="Privacy-first Android apps. No accounts, no ads, no tracking." />
-  <meta name="twitter:image" content="https://ulix.app/icons/favicon.png" />
+  <meta name="twitter:image" content="https://ulix.app/assets/ulixsocialshare1.jpg" />
 
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
@@ -30,6 +32,155 @@
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
   <!-- Shared warm-dark editorial design system (same as the homepage) -->
   <link rel="stylesheet" href="./assets/home.css" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://ulix.app/#org",
+        "name": "Ulix LLC",
+        "alternateName": "Ulix",
+        "url": "https://ulix.app/",
+        "logo": "https://ulix.app/icons/ulixlogomark.png",
+        "sameAs": [
+          "https://play.google.com/store/apps/developer?id=Ulix+LLC"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://ulix.app/#website",
+        "url": "https://ulix.app/",
+        "name": "Ulix",
+        "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+        "publisher": { "@id": "https://ulix.app/#org" },
+        "inLanguage": "en-US"
+      },
+      {
+        "@type": "CollectionPage",
+        "@id": "https://ulix.app/apps.html#webpage",
+        "url": "https://ulix.app/apps.html",
+        "name": "Apps — Ulix",
+        "description": "Privacy-first Android apps from Ulix: Shelf Scan, Keep Clip, Track Analysis, Guten, and more. No accounts, no ads, no tracking.",
+        "isPartOf": { "@id": "https://ulix.app/#website" },
+        "breadcrumb": { "@id": "https://ulix.app/apps.html#breadcrumb" },
+        "mainEntity": { "@id": "https://ulix.app/apps.html#applist" },
+        "inLanguage": "en-US"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": "https://ulix.app/apps.html#breadcrumb",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ulix.app/" },
+          { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://ulix.app/apps.html" }
+        ]
+      },
+      {
+        "@type": "ItemList",
+        "@id": "https://ulix.app/apps.html#applist",
+        "name": "Ulix Android apps",
+        "numberOfItems": 6,
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "item": {
+              "@type": ["SoftwareApplication", "MobileApplication"],
+              "@id": "https://ulix.app/shelfscan/#app",
+              "name": "Shelf Scan",
+              "description": "Find books, movies, and games on physical shelves using your phone's camera. On-device OCR works fully offline. No accounts, no data collection.",
+              "url": "https://ulix.app/shelfscan/",
+              "image": "https://ulix.app/icons/shelfscan.png",
+              "operatingSystem": "Android",
+              "applicationCategory": "UtilitiesApplication",
+              "offers": { "@type": "Offer", "price": "2.99", "priceCurrency": "USD", "availability": "https://schema.org/InStock", "url": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan" },
+              "publisher": { "@id": "https://ulix.app/#org" }
+            }
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "item": {
+              "@type": ["SoftwareApplication", "MobileApplication"],
+              "@id": "https://ulix.app/keepclip/#app",
+              "name": "Keep Clip",
+              "description": "Save notes, quotes, highlights, excerpts, and links from almost any app. Works offline. No accounts. No ads. Export to Markdown, CSV, TXT, RTF, or HTML.",
+              "url": "https://ulix.app/keepclip/",
+              "image": "https://ulix.app/icons/keepclip.png",
+              "operatingSystem": "Android",
+              "applicationCategory": "ProductivityApplication",
+              "offers": { "@type": "Offer", "price": "1.99", "priceCurrency": "USD", "availability": "https://schema.org/InStock", "url": "https://play.google.com/store/apps/details?id=com.bhunt.keepclip" },
+              "publisher": { "@id": "https://ulix.app/#org" }
+            }
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "item": {
+              "@type": ["SoftwareApplication", "MobileApplication"],
+              "@id": "https://ulix.app/trackanalysis/#app",
+              "name": "Track Analysis",
+              "description": "Freeform wellness logging in plain English — food, symptoms, supplements, sleep, activity, and energy. Export clean CSV for your favorite LLM. Offline-first.",
+              "url": "https://ulix.app/trackanalysis/",
+              "image": "https://ulix.app/icons/trackanalysis.png",
+              "operatingSystem": "Android",
+              "applicationCategory": "HealthApplication",
+              "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD", "availability": "https://schema.org/InStock", "url": "https://play.google.com/store/apps/details?id=com.ulix.trackanalysis" },
+              "publisher": { "@id": "https://ulix.app/#org" }
+            }
+          },
+          {
+            "@type": "ListItem",
+            "position": 4,
+            "item": {
+              "@type": ["SoftwareApplication", "MobileApplication"],
+              "@id": "https://ulix.app/guten/#app",
+              "name": "Guten",
+              "description": "A free Android EPUB reader for 70,000+ public-domain books from Project Gutenberg. Read offline, highlight, annotate, and export notes. No account. No ads.",
+              "url": "https://ulix.app/guten/",
+              "image": "https://ulix.app/icons/guten.png",
+              "operatingSystem": "Android",
+              "applicationCategory": "BookApplication",
+              "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD", "availability": "https://schema.org/InStock", "url": "https://play.google.com/store/apps/details?id=com.bhunt.guten" },
+              "publisher": { "@id": "https://ulix.app/#org" }
+            }
+          },
+          {
+            "@type": "ListItem",
+            "position": 5,
+            "item": {
+              "@type": ["SoftwareApplication", "MobileApplication"],
+              "@id": "https://ulix.app/apps.html#loanit",
+              "name": "Loan It",
+              "description": "Track what you lent, who has it, and when it needs to come back. Add photos, contacts, and reminders. Coming soon.",
+              "url": "https://ulix.app/apps.html",
+              "image": "https://ulix.app/icons/loanit.png",
+              "operatingSystem": "Android",
+              "applicationCategory": "UtilitiesApplication",
+              "publisher": { "@id": "https://ulix.app/#org" }
+            }
+          },
+          {
+            "@type": "ListItem",
+            "position": 6,
+            "item": {
+              "@type": ["SoftwareApplication", "MobileApplication"],
+              "@id": "https://ulix.app/apps.html#curiousair",
+              "name": "Curious Air",
+              "description": "Explore the signals in the air around you — Wi-Fi, Cellular, Bluetooth, satellites, and more. Local CSV export. Coming soon.",
+              "url": "https://ulix.app/apps.html",
+              "image": "https://ulix.app/icons/curiousair.png",
+              "operatingSystem": "Android",
+              "applicationCategory": "UtilitiesApplication",
+              "publisher": { "@id": "https://ulix.app/#org" }
+            }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
 </head>
 
 <body class="home-page">

--- a/guten/index.html
+++ b/guten/index.html
@@ -77,7 +77,9 @@
       "offers": {
         "@type": "Offer",
         "price": "0",
-        "priceCurrency": "USD"
+        "priceCurrency": "USD",
+        "availability": "https://schema.org/InStock",
+        "url": "https://play.google.com/store/apps/details?id=com.bhunt.guten"
       },
       "featureList": [
         "Search the Project Gutenberg catalog",
@@ -113,6 +115,44 @@
       "logo": "https://ulix.app/icons/ulixlogomark.png",
       "sameAs": [
         "https://play.google.com/store/apps/developer?id=Ulix+LLC"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://ulix.app/#website",
+      "url": "https://ulix.app/",
+      "name": "Ulix",
+      "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+      "publisher": { "@id": "https://ulix.app/#org" },
+      "inLanguage": "en-US"
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://ulix.app/guten/#webpage",
+      "url": "https://ulix.app/guten/",
+      "name": "Guten — Free Android Ereader for 70,000+ Classics",
+      "description": "Guten is a free Android ereader for Project Gutenberg. Search and download from 70,000+ public-domain classics. Read offline. No account. No ads.",
+      "isPartOf": { "@id": "https://ulix.app/#website" },
+      "about": { "@id": "https://ulix.app/guten/#app" },
+      "mainEntity": { "@id": "https://ulix.app/guten/#app" },
+      "breadcrumb": { "@id": "https://ulix.app/guten/#breadcrumb" },
+      "primaryImageOfPage": {
+        "@type": "ImageObject",
+        "url": "https://ulix.app/assets/guten/gutenshare.jpg",
+        "width": 1200,
+        "height": 630
+      },
+      "inLanguage": "en-US",
+      "datePublished": "2026-05-06",
+      "dateModified": "2026-05-06"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://ulix.app/guten/#breadcrumb",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ulix.app/" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://ulix.app/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Guten", "item": "https://ulix.app/guten/" }
       ]
     }
   ]

--- a/shelfscan/duplicates/index.html
+++ b/shelfscan/duplicates/index.html
@@ -123,11 +123,42 @@
       "embedUrl": "https://www.youtube-nocookie.com/embed/kf6yH4qhzdI"
     },
     {
+      "@type": "WebSite",
+      "@id": "https://ulix.app/#website",
+      "url": "https://ulix.app/",
+      "name": "Ulix",
+      "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+      "publisher": { "@id": "https://ulix.app/#org" },
+      "inLanguage": "en-US"
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://ulix.app/shelfscan/duplicates/#webpage",
+      "url": "https://ulix.app/shelfscan/duplicates/",
+      "name": "Shelf Scan: Stop Buying Duplicate Books",
+      "description": "Save shelf photos at home. Check before you buy at any store. Stop rebuying books, DVDs, and games you already own. On-device, offline, private. $2.99 one-time on Google Play.",
+      "isPartOf": { "@id": "https://ulix.app/#website" },
+      "about": { "@id": "https://ulix.app/shelfscan/#app" },
+      "mainEntity": { "@id": "https://ulix.app/shelfscan/#app" },
+      "breadcrumb": { "@id": "https://ulix.app/shelfscan/duplicates/#breadcrumb" },
+      "primaryImageOfPage": {
+        "@type": "ImageObject",
+        "url": "https://ulix.app/assets/shelfscan/shelfscansocialshare.jpg",
+        "width": 1200,
+        "height": 633
+      },
+      "inLanguage": "en-US",
+      "datePublished": "2026-05-15",
+      "dateModified": "2026-05-15"
+    },
+    {
       "@type": "BreadcrumbList",
+      "@id": "https://ulix.app/shelfscan/duplicates/#breadcrumb",
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ulix.app/" },
         { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://ulix.app/apps.html" },
-        { "@type": "ListItem", "position": 3, "name": "Shelf Scan", "item": "https://ulix.app/shelfscan/" }
+        { "@type": "ListItem", "position": 3, "name": "Shelf Scan", "item": "https://ulix.app/shelfscan/" },
+        { "@type": "ListItem", "position": 4, "name": "Stop Buying Duplicate Books", "item": "https://ulix.app/shelfscan/duplicates/" }
       ]
     }
   ]


### PR DESCRIPTION
Items 5–7 from the SEO/machine-ingestion assessment.

## apps.html (item 7)
- New JSON-LD `@graph`: `CollectionPage` + `BreadcrumbList` + an `ItemList` of all six apps, including the upcoming Loan It and Curious Air, which previously existed nowhere in structured data.
- The four live apps are linked to their canonical `#app` `@id`s, so this graph stitches together with each app page's own markup; all reference the shared `#org` publisher.
- Share image upgraded from the 64×64 favicon to the 1200×633 social card (`summary_large_image`).

## guten/ (item 6)
- Brought up to the Track Analysis standard: `WebSite`, `WebPage`, and `BreadcrumbList` nodes added.
- Offer gains `availability` and `url`.

## shelfscan/duplicates/ (item 5)
- The page was carrying a verbatim clone of the Shelf Scan page's graph, with a breadcrumb that never mentioned the duplicates page itself.
- It now has its own `WebPage` node (name, description, dates, share-card `primaryImageOfPage`) and a four-level breadcrumb ending at "Stop Buying Duplicate Books", with the app still referenced by its canonical `@id`.

All JSON-LD blocks across the site validated as parseable JSON after the change.

https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo)_