### PR TITLE
Rewrite About page with product-forward focus

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,21 +3,24 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About — Ulix</title>
-  <meta name="description" content="Why Ulix: privacy-first design, focused tools, built on products not data." />
+  <title>About Ulix — Android Apps for Information People</title>
+  <meta name="description" content="Ulix makes privacy-first Android apps for readers, collectors, and researchers: Guten, Shelf Scan, Keep Clip, and Track Analysis. Simple tools that do one job and stay out of the way." />
   <link rel="canonical" href="https://ulix.app/about.html" />
   <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
-  <meta property="og:title" content="About — Ulix" />
-  <meta property="og:description" content="Why Ulix: privacy-first design, focused tools, built on products not data." />
+  <meta property="og:title" content="About Ulix — Android Apps for Information People" />
+  <meta property="og:description" content="Ulix makes privacy-first Android apps for readers, collectors, and researchers: Guten, Shelf Scan, Keep Clip, and Track Analysis." />
   <meta property="og:url" content="https://ulix.app/about.html" />
-  <meta property="og:image" content="https://ulix.app/icons/favicon.png" />
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="About — Ulix" />
-  <meta name="twitter:description" content="Why Ulix: privacy-first design, focused tools, built on products not data." />
-  <meta name="twitter:image" content="https://ulix.app/icons/favicon.png" />
+  <meta property="og:image" content="https://ulix.app/assets/ulixsocialshare1.jpg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="633" />
+  <meta property="og:image:alt" content="Ulix — Apps for information people. Android apps for readers, collectors, and researchers." />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="About Ulix — Android Apps for Information People" />
+  <meta name="twitter:description" content="Ulix makes privacy-first Android apps for readers, collectors, and researchers: Guten, Shelf Scan, Keep Clip, and Track Analysis." />
+  <meta name="twitter:image" content="https://ulix.app/assets/ulixsocialshare1.jpg" />
 
   <link rel="icon" href="./icons/favicon.png" type="image/png" />
   <link rel="apple-touch-icon" href="./icons/favicon.png" />
@@ -30,6 +33,76 @@
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
   <!-- Shared warm-dark editorial design system (same as the homepage) -->
   <link rel="stylesheet" href="./assets/home.css" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://ulix.app/#org",
+        "name": "Ulix",
+        "legalName": "Ulix LLC",
+        "url": "https://ulix.app/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://ulix.app/icons/ulixlogomark.png",
+          "width": 128,
+          "height": 128
+        },
+        "slogan": "Precision tools for modern odysseys",
+        "description": "Ulix makes privacy-first Android apps for readers, collectors, and researchers. No accounts, no ads, no tracking.",
+        "founder": { "@type": "Person", "name": "Bethany Hunt" },
+        "sameAs": [
+          "https://play.google.com/store/apps/developer?id=Ulix+LLC"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://ulix.app/#website",
+        "url": "https://ulix.app/",
+        "name": "Ulix",
+        "description": "Privacy-first Android apps from Ulix. No accounts, no ads, no tracking.",
+        "publisher": { "@id": "https://ulix.app/#org" },
+        "inLanguage": "en-US"
+      },
+      {
+        "@type": "AboutPage",
+        "@id": "https://ulix.app/about.html#webpage",
+        "url": "https://ulix.app/about.html",
+        "name": "About Ulix — Android Apps for Information People",
+        "description": "Ulix makes privacy-first Android apps for readers, collectors, and researchers: Guten, Shelf Scan, Keep Clip, and Track Analysis. Simple tools that do one job and stay out of the way.",
+        "isPartOf": { "@id": "https://ulix.app/#website" },
+        "about": { "@id": "https://ulix.app/#org" },
+        "mainEntity": { "@id": "https://ulix.app/#org" },
+        "breadcrumb": { "@id": "https://ulix.app/about.html#breadcrumb" },
+        "inLanguage": "en-US",
+        "dateModified": "2026-06-12"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": "https://ulix.app/about.html#breadcrumb",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ulix.app/" },
+          { "@type": "ListItem", "position": 2, "name": "About", "item": "https://ulix.app/about.html" }
+        ]
+      }
+    ]
+  }
+  </script>
+
+  <style>
+    /* About page app list + CTA, scoped to the shared doc/prose-card layout */
+    .about-apps { margin-top: 18px; display: flex; flex-direction: column; gap: 16px; }
+    .about-app { display: flex; align-items: flex-start; gap: 14px; }
+    .about-app__icon { width: 44px; height: 44px; border-radius: 10px; flex-shrink: 0; }
+    .about-app__icon--sm { width: 32px; height: 32px; border-radius: 8px; }
+    .about-app__icons { display: flex; align-items: center; gap: 8px; flex-shrink: 0; min-width: 44px; }
+    .about-app p { margin: 2px 0 0; }
+    .about-app__name { font-weight: 600; }
+    .about-app__price { color: var(--subtle, rgba(244,239,230,0.45)); }
+    .about-cta { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; margin-top: 28px; }
+  </style>
 </head>
 
 <body class="home-page">
@@ -46,7 +119,7 @@
         <a href="./index.html" class="site-nav__link">Home</a>
         <a href="./apps.html" class="site-nav__link">Apps</a>
         <a href="./blog.html" class="site-nav__link">Blog</a>
-        <a href="./about.html" class="site-nav__link">About</a>
+        <a href="./about.html" class="site-nav__link" aria-current="page">About</a>
         <a href="./contact.html" class="site-nav__link">Contact</a>
       </nav>
       <div class="site-header__actions">
@@ -88,28 +161,53 @@
     <div class="doc">
       <div class="doc-hero">
         <h1 class="doc-hero__title">About Ulix</h1>
-        <p class="doc-hero__lede">Precision Tools for Modern Odysseys</p>
+        <p class="doc-hero__lede">Ulix makes Android apps for <em>information</em> people.</p>
       </div>
+
       <div class="prose-card">
-        <h2>Privacy First</h2>
-        <p>We believe your data should remain yours. That’s why every Ulix app is built local-first: they run on your device, work offline, and don’t depend on cloud services.
-              We don’t run ads, track behavior, or ask for intrusive permissions. If an account isn’t essential, we don’t require one. Privacy isn’t an extra feature; it’s one of the foundations of what we do.</p>
+        <p class="lead">For readers, collectors, researchers, and anyone who loves books, text, notes, and records. If your shelves are full, your highlights are scattered, and you keep meaning to track things properly, there's probably an app here for you.</p>
+
+        <h2>The apps</h2>
+        <div class="about-apps">
+          <div class="about-app">
+            <img src="./icons/guten.png" alt="" class="about-app__icon" width="128" height="128" />
+            <p><a href="./guten/" class="about-app__name">Guten</a> &nbsp;Read 70,000+ public-domain classics offline. <span class="about-app__price">Free, with optional Pro features.</span></p>
+          </div>
+          <div class="about-app">
+            <img src="./icons/shelfscan.png" alt="" class="about-app__icon" width="128" height="128" />
+            <p><a href="./shelfscan/" class="about-app__name">Shelf Scan</a> &nbsp;Search your shelves with the camera. <span class="about-app__price">$2.99.</span></p>
+          </div>
+          <div class="about-app">
+            <img src="./icons/keepclip.png" alt="" class="about-app__icon" width="128" height="128" loading="lazy" decoding="async" />
+            <p><a href="./keepclip/" class="about-app__name">Keep Clip</a> &nbsp;Save text and links from any app. Export to your format of choice. <span class="about-app__price">$1.99.</span></p>
+          </div>
+          <div class="about-app">
+            <img src="./icons/trackanalysis.png" alt="" class="about-app__icon" width="128" height="128" loading="lazy" decoding="async" />
+            <p><a href="./trackanalysis/" class="about-app__name">Track Analysis</a> &nbsp;Log anything in plain English, export CSV. <span class="about-app__price">Free, with a one-time Pro unlock.</span></p>
+          </div>
+          <div class="about-app">
+            <span class="about-app__icons">
+              <img src="./icons/loanit.png" alt="" class="about-app__icon about-app__icon--sm" width="128" height="128" loading="lazy" decoding="async" />
+              <img src="./icons/curiousair.png" alt="" class="about-app__icon about-app__icon--sm" width="128" height="128" loading="lazy" decoding="async" />
+            </span>
+            <p><a href="./apps.html" class="about-app__name">Loan It</a> · <a href="./apps.html" class="about-app__name">Curious Air</a> &nbsp;<span class="about-app__price">Coming this year.</span></p>
+          </div>
+        </div>
       </div>
+
       <div class="prose-card">
-        <h2>Curated by Design</h2>
-        <p>Ulix apps are not generic utilities. They are shaped by our founder’s particular aesthetic vision. If you share that vision, you’ll feel at home.
-              We design for a specific taste: apps that feel good to use, not because they’re flashy, but because they are intuitive, elegant, and intentional.</p>
+        <h2>The idea</h2>
+        <p>Ulix apps are simple on purpose. Each one does a specific job: finding a book, saving a passage, keeping a log. Then it gets out of the way. They're built to be quick to learn, pleasant to use, and easy to leave. Your data exports to ordinary formats you can take anywhere.</p>
+        <p>The business model is old-fashioned: the apps are the product. Buy a good tool, own a good tool. No ads to distract or track you, no engagement farming, no reason for the software to want anything from you beyond doing its job well.</p>
       </div>
+
       <div class="prose-card">
-        <h2>Focused Tools</h2>
-        <p>Software should help you get back to your real life, not trap you on a screen. Each Ulix app has a clear purpose and a clean interface.
-              No bloat, no noisy notifications, no attention-grabs. Ulix apps are built to be lightweight companions that extend your abilities and then step aside, so you can focus on what actually matters.</p>
-      </div>
-      <div class="prose-card">
-        <h2>Built on Products, Not Data</h2>
-        <p>Most modern apps are free because you’re the product. Ulix takes the harder road: we sell our apps, not our customers.
-              That choice costs us revenue opportunities, but it keeps us aligned with you. Our business model is simple: you pay us for good tools, and we build good tools.
-              No hidden agendas, no monetizing of you.</p>
+        <h2>Behind Ulix</h2>
+        <p>Ulix is a small, independent software company founded by Bethany Hunt. Every app starts the same way: as something worth using every day. The ones that earn their keep get finished and shipped.</p>
+        <div class="about-cta">
+          <a href="./apps.html" class="btn btn--primary">Browse all apps</a>
+          <span>Questions? <a href="./contact.html">Get in touch</a>.</span>
+        </div>
       </div>
     </div>
   </main>
@@ -120,7 +218,7 @@
       <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand">
-          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" />
+          <img src="./icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" loading="lazy" decoding="async" />
         </div>
         <div class="site-footer__links">
           <a href="./apps.html">Apps</a>

--- a/apps.html
+++ b/apps.html
@@ -40,8 +40,8 @@
       {
         "@type": "Organization",
         "@id": "https://ulix.app/#org",
-        "name": "Ulix LLC",
-        "alternateName": "Ulix",
+        "name": "Ulix",
+        "legalName": "Ulix LLC",
         "url": "https://ulix.app/",
         "logo": "https://ulix.app/icons/ulixlogomark.png",
         "sameAs": [
@@ -53,7 +53,7 @@
         "@id": "https://ulix.app/#website",
         "url": "https://ulix.app/",
         "name": "Ulix",
-        "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+        "description": "Privacy-first Android apps from Ulix. No accounts, no ads, no tracking.",
         "publisher": { "@id": "https://ulix.app/#org" },
         "inLanguage": "en-US"
       },

--- a/guten/index.html
+++ b/guten/index.html
@@ -109,8 +109,8 @@
     {
       "@type": "Organization",
       "@id": "https://ulix.app/#org",
-      "name": "Ulix LLC",
-      "alternateName": "Ulix",
+      "name": "Ulix",
+      "legalName": "Ulix LLC",
       "url": "https://ulix.app/",
       "logo": "https://ulix.app/icons/ulixlogomark.png",
       "sameAs": [
@@ -122,7 +122,7 @@
       "@id": "https://ulix.app/#website",
       "url": "https://ulix.app/",
       "name": "Ulix",
-      "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+      "description": "Privacy-first Android apps from Ulix. No accounts, no ads, no tracking.",
       "publisher": { "@id": "https://ulix.app/#org" },
       "inLanguage": "en-US"
     },

--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
       {
         "@type": "Organization",
         "@id": "https://ulix.app/#org",
-        "name": "Ulix LLC",
-        "alternateName": "Ulix",
+        "name": "Ulix",
+        "legalName": "Ulix LLC",
         "url": "https://ulix.app/",
         "logo": {
           "@type": "ImageObject",
@@ -54,7 +54,8 @@
           "height": 128
         },
         "slogan": "Precision tools for modern odysseys",
-        "description": "Ulix LLC builds privacy-first Android apps for readers, collectors, and researchers. No accounts, no ads, no tracking.",
+        "description": "Ulix makes privacy-first Android apps for readers, collectors, and researchers. No accounts, no ads, no tracking.",
+        "founder": { "@type": "Person", "name": "Bethany Hunt" },
         "sameAs": [
           "https://play.google.com/store/apps/developer?id=Ulix+LLC"
         ]
@@ -64,7 +65,7 @@
         "@id": "https://ulix.app/#website",
         "url": "https://ulix.app/",
         "name": "Ulix",
-        "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+        "description": "Privacy-first Android apps from Ulix. No accounts, no ads, no tracking.",
         "publisher": { "@id": "https://ulix.app/#org" },
         "inLanguage": "en-US"
       }

--- a/keepclip/index.html
+++ b/keepclip/index.html
@@ -84,8 +84,8 @@
     {
       "@type": "Organization",
       "@id": "https://ulix.app/#org",
-      "name": "Ulix LLC",
-      "alternateName": "Ulix",
+      "name": "Ulix",
+      "legalName": "Ulix LLC",
       "url": "https://ulix.app/",
       "logo": "https://ulix.app/icons/ulixlogomark.png",
       "sameAs": [

--- a/shelfscan/duplicates/index.html
+++ b/shelfscan/duplicates/index.html
@@ -104,8 +104,8 @@
     {
       "@type": "Organization",
       "@id": "https://ulix.app/#org",
-      "name": "Ulix LLC",
-      "alternateName": "Ulix",
+      "name": "Ulix",
+      "legalName": "Ulix LLC",
       "url": "https://ulix.app/",
       "logo": "https://ulix.app/icons/ulixlogomark.png",
       "sameAs": [
@@ -127,7 +127,7 @@
       "@id": "https://ulix.app/#website",
       "url": "https://ulix.app/",
       "name": "Ulix",
-      "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+      "description": "Privacy-first Android apps from Ulix. No accounts, no ads, no tracking.",
       "publisher": { "@id": "https://ulix.app/#org" },
       "inLanguage": "en-US"
     },

--- a/shelfscan/index.html
+++ b/shelfscan/index.html
@@ -103,8 +103,8 @@
     {
       "@type": "Organization",
       "@id": "https://ulix.app/#org",
-      "name": "Ulix LLC",
-      "alternateName": "Ulix",
+      "name": "Ulix",
+      "legalName": "Ulix LLC",
       "url": "https://ulix.app/",
       "logo": "https://ulix.app/icons/ulixlogomark.png",
       "sameAs": [

--- a/trackanalysis/index.html
+++ b/trackanalysis/index.html
@@ -67,8 +67,8 @@
       {
         "@type": "Organization",
         "@id": "https://ulix.app/#org",
-        "name": "Ulix LLC",
-        "alternateName": "Ulix",
+        "name": "Ulix",
+        "legalName": "Ulix LLC",
         "url": "https://ulix.app/",
         "logo": {
           "@type": "ImageObject",
@@ -86,7 +86,7 @@
         "@id": "https://ulix.app/#website",
         "url": "https://ulix.app/",
         "name": "Ulix",
-        "description": "Privacy-first Android apps from Ulix LLC. No accounts, no ads, no tracking.",
+        "description": "Privacy-first Android apps from Ulix. No accounts, no ads, no tracking.",
         "publisher": { "@id": "https://ulix.app/#org" },
         "inLanguage": "en-US"
       },


### PR DESCRIPTION
Item 2 from the assessment: the About page rewritten with a product-forward focus, per the approved copy.

## Page content
- **Hero:** "About Ulix" with the lede "Ulix makes Android apps for *information* people."
- **The apps:** compact list (icon, linked name, one-line description, muted price) for Guten, Shelf Scan, Keep Clip, and Track Analysis, plus a "Coming this year" row for Loan It and Curious Air. The page previously named zero products and linked to none.
- **The idea:** the philosophy in two short paragraphs, written as description rather than promises (no universal "every app" claims, since future apps may differ).
- **Behind Ulix:** brief founder note, ending with "Browse all apps" and a contact link.
- Reuses the existing `doc`/`prose-card` design system; the only new CSS is a small scoped block for the app rows.

## Metadata
- Title: `About Ulix — Android Apps for Information People`; description names the apps.
- Share image upgraded from the 64×64 favicon (below Twitter's minimum, so previews failed) to the 1200×633 social card with `summary_large_image`.
- New JSON-LD: `AboutPage` + `BreadcrumbList`, with the Organization node carrying `founder` and `legalName`.

## Sitewide schema follow-through
- All Organization nodes now use `name: "Ulix"` with `legalName: "Ulix LLC"` (Ulix is the registered DBA; `legalName` is the schema.org property for exactly this).
- The homepage's canonical org node gains `founder: Bethany Hunt`.

All eight JSON-LD blocks validate as parseable JSON, and every link on the new About page resolves.

https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo)_