### PR TITLE
About: broaden lede and add Ulix Cortex coming-soon section

### DIFF
--- a/about.html
+++ b/about.html
@@ -92,7 +92,7 @@
         "@id": "https://ulix.app/#cortex",
         "name": "Ulix Cortex",
         "serviceType": "Custom archive and insight service",
-        "description": "A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable archives, surfacing the topics, themes, patterns, and source-backed insights behind books, courses, talks, articles, and other work.",
+        "description": "A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives, surfacing the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other work.",
         "category": "Coming soon",
         "url": "https://ulix.app/about.html#cortex",
         "provider": { "@id": "https://ulix.app/#org" },
@@ -230,7 +230,7 @@
       <div class="prose-card cortex-card" id="cortex">
         <p class="cortex-eyebrow">Coming soon</p>
         <h2>Ulix Cortex</h2>
-        <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights behind books, courses, talks, articles, and other work.</p>
+        <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other work.</p>
         <p>Hands-on, and built around your material, for people sitting on years of it.</p>
         <a href="./contact.html" class="cortex-link">Register your interest →</a>
       </div>

--- a/about.html
+++ b/about.html
@@ -86,6 +86,17 @@
           { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ulix.app/" },
           { "@type": "ListItem", "position": 2, "name": "About", "item": "https://ulix.app/about.html" }
         ]
+      },
+      {
+        "@type": "Service",
+        "@id": "https://ulix.app/#cortex",
+        "name": "Ulix Cortex",
+        "serviceType": "Custom archive and insight service",
+        "description": "A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable archives, surfacing the topics, themes, patterns, and source-backed insights behind books, courses, talks, articles, and other work.",
+        "category": "Coming soon",
+        "url": "https://ulix.app/about.html#cortex",
+        "provider": { "@id": "https://ulix.app/#org" },
+        "areaServed": "Worldwide"
       }
     ]
   }
@@ -102,6 +113,12 @@
     .about-app__name { font-weight: 600; }
     .about-app__price { color: var(--subtle, rgba(244,239,230,0.45)); }
     .about-cta { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; margin-top: 28px; }
+    /* Ulix Cortex coming-soon section */
+    .cortex-card { border-color: rgba(91,163,245,0.4); }
+    .cortex-eyebrow { display: inline-flex; align-items: center; gap: 9px; margin: 0; font-family: var(--sans); font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent); }
+    .cortex-eyebrow::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 4px rgba(91,163,245,0.18); }
+    .cortex-card h2 { margin-top: 14px; }
+    .cortex-link { display: inline-block; margin-top: 22px; font-weight: 600; }
   </style>
 </head>
 
@@ -161,11 +178,11 @@
     <div class="doc">
       <div class="doc-hero">
         <h1 class="doc-hero__title">About Ulix</h1>
-        <p class="doc-hero__lede">Ulix makes Android apps for <em>information</em> people.</p>
+        <p class="doc-hero__lede">Software and services for <em>information</em> people.</p>
       </div>
 
       <div class="prose-card">
-        <p class="lead">For readers, collectors, researchers, and anyone who loves books, text, notes, and records. If your shelves are full, your highlights are scattered, and you keep meaning to track things properly, there's probably an app here for you.</p>
+        <p class="lead">For readers, collectors, researchers, and anyone who loves books, text, notes, and records. If your shelves are full, your highlights are scattered, and you keep meaning to track things properly, there's probably something here for you.</p>
 
         <h2>The apps</h2>
         <div class="about-apps">
@@ -208,6 +225,14 @@
           <a href="./apps.html" class="btn btn--primary">Browse all apps</a>
           <span>Questions? <a href="./contact.html">Get in touch</a>.</span>
         </div>
+      </div>
+
+      <div class="prose-card cortex-card" id="cortex">
+        <p class="cortex-eyebrow">Coming soon</p>
+        <h2>Ulix Cortex</h2>
+        <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights behind books, courses, talks, articles, and other work.</p>
+        <p>Hands-on, and built around your material, for people sitting on years of it.</p>
+        <a href="./contact.html" class="cortex-link">Register your interest →</a>
       </div>
     </div>
   </main>


### PR DESCRIPTION
Follow-up to the About rewrite (#77). About-page-only, as discussed.

## Copy
- **Lede:** "Ulix makes Android apps for information people." → **"Software and services for information people."**
- **Intro:** "...there's probably an **app** here for you." → "...there's probably **something** here for you." so it covers services as well as apps.
- **New closing section — Ulix Cortex:** a "Coming soon" card by itself at the bottom. Describes Cortex as a custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable archives, surfacing the topics, themes, patterns, and source-backed insights behind books, courses, talks, and articles. Closes with a "Register your interest →" inquiry CTA. Em dashes avoided throughout, per your note.

It's styled as its own card (accent-tinted border, "Coming soon" eyebrow) so it reads as a different class of thing from the app list, and the inquiry CTA — rather than a price or download — carries the high-touch/premium signal.

## Structured data
Added a `Service` node to the graph (name "Ulix Cortex", `provider` → `#org`) so the offering is machine-readable alongside the apps.

## One note for you
The page `<title>`/meta still say "About Ulix — Android Apps for Information People." That still describes the indexable substance of the page (the four shipping apps), so I left it. Once Cortex is closer to launch, we can revisit the title and the homepage's "Android apps" framing together as a positioning pass.

https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo)_