### PR TITLE
Add llms.txt, sitemap lastmod, and noindex the placeholder blog

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,6 +6,7 @@
   <title>Blog — Ulix</title>
   <meta name="description" content="Signals from Ulix — updates on new apps, new features, and the occasional idea on tools that serve." />
   <link rel="canonical" href="https://ulix.app/blog.html" />
+  <meta name="robots" content="noindex, follow" />
   <meta name="theme-color" content="#0F0E0C" />
 
   <meta property="og:type" content="website" />

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+# Ulix
+
+> Ulix makes privacy-first Android apps and services for information people: readers, collectors, and researchers. The apps run on the device, work offline, and require no accounts, ads, or tracking. The apps are the product, not user data.
+
+Ulix is a small, independent software company founded by Bethany Hunt (registered as Ulix LLC). Every app starts as something worth using every day; the ones that earn their keep get finished and shipped. Data exports to ordinary, portable formats you can take anywhere.
+
+## Apps
+
+- [Guten](https://ulix.app/guten/): Android ereader for 70,000+ public-domain classics from Project Gutenberg. Read offline, highlight, annotate, and export notes. Free, with optional Pro features.
+- [Shelf Scan](https://ulix.app/shelfscan/): Search physical shelves with your phone's camera using on-device OCR. Finds books, movies, and games. Fully offline, nothing leaves the device. $2.99 one-time.
+- [Keep Clip](https://ulix.app/keepclip/): Save text, quotes, highlights, and links from almost any app via the Share menu. Tag, search, favorite, and export to Markdown, CSV, TXT, RTF, or HTML. $1.99 one-time.
+- [Track Analysis](https://ulix.app/trackanalysis/): Freeform plain-English logging for food, symptoms, supplements, sleep, activity, and energy. Export a clean CSV for analysis with the LLM of your choice. Free, with a one-time Pro unlock.
+- Loan It and Curious Air: Android utilities, coming this year.
+
+## Services
+
+- [Ulix Cortex](https://ulix.app/about.html#cortex) (coming soon): A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives, surfacing the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other work.
+
+## Pages
+
+- [Apps](https://ulix.app/apps.html): Overview of all Ulix apps.
+- [About](https://ulix.app/about.html): The company, the apps, and the approach.
+- [Support](https://ulix.app/support.html): Get help with a Ulix app.
+- [Contact](https://ulix.app/contact.html): Get in touch.
+- [Privacy](https://ulix.app/privacy.html): Privacy overview and links to per-app policies.
+- [Terms](https://ulix.app/terms.html): Terms of Service.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,90 +2,97 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ulix.app/</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ulix.app/apps.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ulix.app/about.html</loc>
-    <changefreq>yearly</changefreq>
+    <lastmod>2026-06-13</lastmod>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://ulix.app/blog.html</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
     <loc>https://ulix.app/contact.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://ulix.app/support.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://ulix.app/privacy.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://ulix.app/terms.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://ulix.app/shelfscanprivacy.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://ulix.app/keepclipprivacypolicy.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://ulix.app/trackanalysisprivacy.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://ulix.app/gutenprivacy.html</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://ulix.app/shelfscan/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ulix.app/shelfscan/duplicates/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ulix.app/guten/</loc>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ulix.app/keepclip/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ulix.app/trackanalysis/</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Backlog items 8, 9, and 10 from the assessment.

## 8 — `/llms.txt` (machine ingestion)
New root `llms.txt` following the emerging convention: an H1, a one-line summary, then sections for **Apps** (each with a one-line description, price, and canonical URL), **Services** (Ulix Cortex, coming soon), and key **Pages**. Gives AI crawlers a clean, structured overview of the company and offerings.

## 9 — sitemap `lastmod`
Every entry now carries a `lastmod`. Google ignores `changefreq`/`priority` but does use `lastmod` as a recrawl hint; previously most entries had none. Dates reflect each file's actual last change (the site-wide schema/image refactor on 2026‑06‑12; the About rewrite on 2026‑06‑13). `changefreq`/`priority` retained as harmless valid elements.

## 10 — blog
The blog is still an empty "Coming Soon" placeholder. Per your call, it's now `noindex, follow` and removed from the sitemap so a thin page isn't indexed. The nav link stays; this is a one-line revert once the first post ships. A real RSS/Atom feed needs at least one post to be valid, so it'll follow with content — not in this PR.

Sitemap validated as well-formed XML (16 URLs, all with `lastmod`); blog confirmed absent from the sitemap and carrying the `noindex` meta.

https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo)_