### PR TITLE
About: revise Ulix Cortex closing line

### DIFF
--- a/about.html
+++ b/about.html
@@ -231,7 +231,7 @@
         <p class="cortex-eyebrow">Coming soon</p>
         <h2>Ulix Cortex</h2>
         <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other works.</p>
-        <p>Hands-on, because your thoughts of years deserve more than a drawer or a stream of online ephemera.</p>
+        <p>Hands on, because your thoughts of years deserve more than a drawer or a stream of online ephemera.</p>
         <a href="./contact.html" class="cortex-link">Register your interest →</a>
       </div>
     </div>

--- a/about.html
+++ b/about.html
@@ -92,7 +92,7 @@
         "@id": "https://ulix.app/#cortex",
         "name": "Ulix Cortex",
         "serviceType": "Custom archive and insight service",
-        "description": "A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives, surfacing the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other work.",
+        "description": "A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives, surfacing the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other works.",
         "category": "Coming soon",
         "url": "https://ulix.app/about.html#cortex",
         "provider": { "@id": "https://ulix.app/#org" },
@@ -230,8 +230,8 @@
       <div class="prose-card cortex-card" id="cortex">
         <p class="cortex-eyebrow">Coming soon</p>
         <h2>Ulix Cortex</h2>
-        <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other work.</p>
-        <p>Hands-on, and built around your material, for people sitting on years of it.</p>
+        <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other works.</p>
+        <p>Hands-on, because your thoughts of years deserve more than a drawer or a stream of online ephemera.</p>
         <a href="./contact.html" class="cortex-link">Register your interest →</a>
       </div>
     </div>

--- a/about.html
+++ b/about.html
@@ -231,7 +231,7 @@
         <p class="cortex-eyebrow">Coming soon</p>
         <h2>Ulix Cortex</h2>
         <p>A custom service that turns scattered outputs (videos, journals, memos, notes, records, and more) into structured, searchable, AI-queryable archives. Cortex surfaces the topics, themes, patterns, and source-backed insights needed to create books, courses, talks, articles, and other works.</p>
-        <p>Hands on, because your thoughts of years deserve more than a drawer or a stream of online ephemera.</p>
+        <p>Hands-on, because your thoughts of years deserve more than a drawer or a stream of online ephemera.</p>
         <a href="./contact.html" class="cortex-link">Register your interest →</a>
       </div>
     </div>


### PR DESCRIPTION
Small copy revision to the Ulix Cortex section on the About page.

- Closing line replaced with: **"Hands-on, because your thoughts of years deserve more than a drawer or a stream of online ephemera."** (your wording and idiom, as requested)
- "other work" → "other **works**" in the Cortex paragraph, kept in sync between the visible copy and the `Service` JSON-LD description so the two don't drift.

JSON-LD re-validated.

https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6kndTqAvLoC6xYhwYidJo)_