### PR TITLE
Update Loan It privacy policy for new backup behavior

### DIFF
--- a/loanitprivacy.html
+++ b/loanitprivacy.html
@@ -135,7 +135,12 @@
         </ul>
 
         <h2>Backups</h2>
-        <p>Loan It is configured to exclude its local database and private files from Android cloud backup and device-transfer extraction rules. This means your loan records and attached images are not intended to be backed up automatically by Android’s built-in backup system.</p>
+        <p>Loan It works with Android’s built-in backup and device-transfer system so your records are not lost if you replace, reset, or restore your device:</p>
+        <ul>
+          <li>When you transfer to a new phone, your full loan records and attached photos can be moved directly to the new device.</li>
+          <li>Your loan records are also included in Android’s cloud backup, so they can be restored on a new or reset device. Attached photos are excluded from cloud backup to keep it within Android’s size limits, so after a cloud restore your records return but photos taken on the previous device may not.</li>
+        </ul>
+        <p>Android backups are encrypted by the operating system and governed by Android’s backup system and your Google Account settings. Whether cloud backup is active depends on your device settings.</p>
 
         <h2>Premium features</h2>
         <p>Loan It offers optional Pro features through Google Play Billing. Purchases and purchase restoration are handled by Google Play. Loan It does not see your payment card details. When you buy or restore a purchase, Google Play confirms your purchase status to the app, and Loan It stores purchase-related status locally so Pro features can be unlocked.</p>


### PR DESCRIPTION
Loan It now backs up loan records via Android's device transfer (with photos) and cloud backup (records only, photos excluded for size), instead of excluding everything. Rewrite the Backups section to describe this split and note that Android backups are encrypted.


Claude-Session: https://claude.ai/code/session_01H4zijYUjdBi3UANu19BdLj