### PR TITLE
Point Ulix Cortex contact email to hello@ulix.app

### DIFF
--- a/ulixcortex/index.html
+++ b/ulixcortex/index.html
@@ -49,7 +49,7 @@
       "legalName": "Ulix LLC",
       "url": "https://ulix.app/"
     },
-    "email": "info@ulixcortex.com"
+    "email": "hello@ulix.app"
   }
   </script>
 </head>
@@ -68,7 +68,7 @@
         <a class="navlink" href="#example">Example</a>
         <a class="navlink" href="#for-you">For You</a>
         <a class="navlink" href="#about">About</a>
-        <a class="btn" href="mailto:info@ulixcortex.com?subject=Beginning%20a%20conversation">Begin a Conversation</a>
+        <a class="btn" href="mailto:hello@ulix.app?subject=Beginning%20a%20conversation">Begin a Conversation</a>
       </nav>
     </div>
   </header>
@@ -82,7 +82,7 @@
           <p class="eyebrow">A Custom Research Service</p>
           <h1>Turn a lifetime of&nbsp;work into a structured archive.</h1>
           <p class="lede">We help executives, creatives, and scholars preserve what matters&mdash;transforming scattered materials into organized archives and cited research artifacts.</p>
-          <a class="btn" href="mailto:info@ulixcortex.com?subject=Beginning%20a%20conversation">Begin a Conversation</a>
+          <a class="btn" href="mailto:hello@ulix.app?subject=Beginning%20a%20conversation">Begin a Conversation</a>
         </div>
         <div class="hero-art" aria-hidden="true">
           <img src="/ulixcortex/assets/cortexhero-1200.webp" srcset="/ulixcortex/assets/cortexhero-800.webp 800w, /ulixcortex/assets/cortexhero-1200.webp 1200w" sizes="(max-width: 820px) 100vw, 640px" width="1200" height="1148" alt="" loading="eager" decoding="async" />
@@ -299,7 +299,7 @@
         <div class="inner">
           <p class="eyebrow" style="text-align:center">About</p>
           <p>Ulix Cortex is the custom research practice of <a href="https://ulix.app/">Ulix LLC</a>. Every engagement is private and bespoke: your materials stay in your custody, and everything we produce is traceable back to its source.</p>
-          <p>Write to us at <a href="mailto:info@ulixcortex.com">info@ulixcortex.com</a>.</p>
+          <p>Write to us at <a href="mailto:hello@ulix.app">hello@ulix.app</a>.</p>
         </div>
       </div>
     </section>
@@ -308,7 +308,7 @@
     <section class="cta">
       <div class="container">
         <h2>Build your archive. Preserve what matters.</h2>
-        <a class="btn" href="mailto:info@ulixcortex.com?subject=Beginning%20a%20conversation">Begin a Conversation</a>
+        <a class="btn" href="mailto:hello@ulix.app?subject=Beginning%20a%20conversation">Begin a Conversation</a>
       </div>
     </section>
 
@@ -321,7 +321,7 @@
         <span>&copy; 2026 Ulix Cortex</span>
       </span>
       <span>Private<span class="sep" aria-hidden="true">&bull;</span>Discreet<span class="sep" aria-hidden="true">&bull;</span>Source-Traceable</span>
-      <a href="mailto:info@ulixcortex.com">info@ulixcortex.com</a>
+      <a href="mailto:hello@ulix.app">hello@ulix.app</a>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- Follow-up to the merged Ulix Cortex landing page (#86): updates all `mailto:` links and the JSON-LD `email` field from `info@ulixcortex.com` to `hello@ulix.app`.

## Test plan
- [x] Verified no remaining references to `ulixcortex.com` in `ulixcortex/index.html`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgyxCgXrXCPjEduYUGReTG)_