### PR TITLE
Update Loan It privacy policy for release

### DIFF
--- a/loanitprivacy.html
+++ b/loanitprivacy.html
@@ -78,7 +78,7 @@
     <div class="doc">
       <div class="doc-hero">
         <h1 class="doc-hero__title">Loan It — Privacy Policy</h1>
-        <div class="doc-hero__meta">Last updated: June 30, 2026</div>
+        <div class="doc-hero__meta">Last updated: July 12, 2026</div>
       </div>
       <div class="prose-card">
         <p class="lead">Loan It is an app for keeping track of physical items you lend to other people, designed to keep your loan records under your control.</p>
@@ -114,15 +114,15 @@
         </ul>
 
         <h2>Contacts, camera, photos, and reminders</h2>
-        <p>Loan It may request access to device features only when needed for app functionality:</p>
+        <p>Loan It uses device features only when needed for app functionality:</p>
         <ul>
-          <li>Contacts access is used so you can choose a borrower from your contacts. Loan It reads the selected contact name for your loan record.</li>
+          <li>Android’s contact picker lets you choose a borrower. Android grants temporary access only to the selected contact; Loan It reads the selected display name and does not request access to the full address book.</li>
           <li>Camera access is used for taking item photos and scanning book barcodes.</li>
           <li>Notification permission is used for due date reminders.</li>
-          <li>Exact alarm permission may be requested so reminders can be delivered at the scheduled time.</li>
+          <li>Ordinary Android alarm scheduling is used to deliver reminders around the selected day and time. Loan It does not request exact-alarm access.</li>
           <li>Reboot access is used to reschedule reminders after your device restarts.</li>
         </ul>
-        <p>These permissions are used for the features you choose to use.</p>
+        <p>These device features and permissions are used only for the functions you choose to use.</p>
 
         <h2>When data may leave your device</h2>
         <p>Your loan data stays on your device unless you take an action that causes it to leave, such as:</p>
@@ -133,6 +133,7 @@
           <li>scanning or looking up an ISBN, which sends the ISBN to Open Library, or</li>
           <li>making or restoring a Pro purchase through Google Play Billing.</li>
         </ul>
+        <p>CSV and JSON exports contain loan details and borrower names. They do not include attached photo files or device-specific contact links.</p>
 
         <h2>Backups</h2>
         <p>Loan It works with Android’s built-in backup and device-transfer system so your records are not lost if you replace, reset, or restore your device:</p>
@@ -155,7 +156,7 @@
         <p>These services may receive standard technical request data, such as IP address and request headers, as part of normal internet communication. Their privacy policies apply to that processing.</p>
 
         <h2>Your controls</h2>
-        <p>You can delete loan records and attached images from within the app. You can also export your data if you want to keep your own backup or move your records.</p>
+        <p>You can delete loan records and attached images from within the app. You can also export a portable copy of loan details and borrower names. Full-device recovery is handled through Android backup and device transfer as described above.</p>
         <p>Loan It is designed to help you keep track of what you lend while minimizing data collection and keeping your records under your control.</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Update the Loan It privacy policy date to July 12, 2026.
- Explain that Loan It uses Android’s scoped contact picker and does not request access to the full address book.
- Remove the obsolete exact-alarm permission language.
- Clarify that reminders use ordinary Android alarm scheduling and notification permission.
- Explain that CSV and JSON exports contain loan details and borrower names but not photo files or device-specific contact links.
- Distinguish portable text exports from Android backup and device-to-device transfer.

## Why

The app’s pre-release permission and export behavior changed in recent Loan It pull requests. The published policy should match the version linked from the new in-app About & privacy section.