### PR TITLE
Add Breaker of Horses and Scepter to support

### DIFF
--- a/support.html
+++ b/support.html
@@ -115,6 +115,8 @@
               <option>Shelf Scan</option>
               <option>Keep Clip</option>
               <option>Guten</option>
+              <option>Breaker of Horses</option>
+              <option>Scepter</option>
               <option>Loan It</option>
               <option>Track Analysis</option>
               <option>Curious Air</option>


### PR DESCRIPTION
## What changed

- Adds **Breaker of Horses** to the app selector on the Ulix support form.
- Adds **Scepter** to the same selector.
- Leaves the form destination, validation, styling, and all other support-page content unchanged.

## Validation

- Compared the branch against the current `new` branch.
- Confirmed the diff contains exactly two added `<option>` elements in `support.html`.