### PR TITLE
Add Breaker of Horses to the homepage

### DIFF
--- a/assets/home.css
+++ b/assets/home.css
@@ -612,3 +612,145 @@
   justify-content: center;
   flex-wrap: wrap;
 }
+
+
+/* ---------- Compact secondary reader card ---------- */
+.home-page .reader-card {
+  margin-top: 28px;
+  min-height: 270px;
+  padding: 28px;
+  border: 1px solid var(--rule);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), transparent 55%);
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(150px, 0.45fr) minmax(230px, 0.6fr);
+  gap: 28px;
+  align-items: center;
+}
+.home-page .reader-card:hover { border-color: rgba(244,239,230,0.22); }
+.home-page .reader-card__copy .app-card__head { margin-bottom: 18px; }
+.home-page .reader-card__headline {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(25px, 2.5vw, 31px);
+  letter-spacing: -0.015em;
+  line-height: 1.08;
+  color: var(--fg);
+}
+.home-page .reader-card__body {
+  max-width: 500px;
+  margin-top: 12px;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+.home-page .reader-card__body i { font-family: var(--serif); font-size: 1.08em; }
+.home-page .reader-card__features {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-left: 26px;
+  border-left: 1px solid var(--rule);
+}
+.home-page .reader-card__features li {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.11em;
+  line-height: 1.45;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.home-page .reader-card__features li::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  background: var(--accent);
+  transform: rotate(45deg);
+}
+.home-page .reader-card__visual {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 18px;
+}
+.home-page .reader-card__phone {
+  width: 106px;
+  height: 216px;
+  margin: 0;
+  padding: 5px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 18px;
+  background: #050505;
+  box-shadow: 0 18px 42px rgba(0,0,0,0.32);
+}
+.home-page .reader-card__phone img {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
+  object-fit: cover;
+  object-position: top;
+}
+.home-page .reader-card__actions {
+  min-width: 104px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+}
+.home-page .reader-card__get {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 9px 15px;
+  border: 1px solid var(--fg);
+  border-radius: 999px;
+  background: var(--fg);
+  color: var(--bg);
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: transform 0.15s;
+}
+.home-page .reader-card__get:hover { transform: translateY(-1px); }
+
+@media (max-width: 900px) {
+  .home-page .reader-card {
+    grid-template-columns: minmax(0, 1fr) minmax(140px, 0.4fr) minmax(210px, 0.55fr);
+    gap: 22px;
+  }
+  .home-page .reader-card__features { padding-left: 20px; }
+}
+
+@media (max-width: 760px) {
+  .home-page .reader-card {
+    grid-template-columns: 1fr;
+    gap: 22px;
+    margin-top: 20px;
+    min-height: 0;
+    padding: 24px;
+  }
+  .home-page .reader-card__features {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 12px 20px;
+    padding: 20px 0 0;
+    border-top: 1px solid var(--rule);
+    border-left: 0;
+  }
+  .home-page .reader-card__features li { width: calc(50% - 10px); }
+  .home-page .reader-card__visual {
+    justify-content: flex-start;
+    padding-top: 22px;
+    border-top: 1px solid var(--rule);
+  }
+  .home-page .reader-card__phone { width: 104px; height: 212px; }
+  .home-page .reader-card__actions { gap: 14px; }
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ulix — Apps for information people</title>
-  <meta name="description" content="Six Android apps for collecting, searching, scanning, saving, reading, and logging the information in your life — built to help you understand it. Free to start. No accounts. Works offline." />
+  <meta name="description" content="Android apps for collecting, searching, scanning, saving, reading, and logging the information in your life. Built to help you understand it. Free to start. No accounts. Works offline." />
   <link rel="canonical" href="https://ulix.app/" />
   <meta name="theme-color" content="#0F0E0C" />
 
@@ -168,7 +168,7 @@
               <div class="phone-screen"><img src="./assets/screenshots/keepclip/keepclipmain.webp" alt="Keep Clip saved clips" width="1080" height="2277" /></div>
             </div>
             <div class="phone" style="--s:0.6; --r:9deg; z-index:1;">
-              <div class="phone-screen"><img src="./assets/screenshots/guten/reading_dark.webp" alt="Guten dark reading view" width="1080" height="2134" /></div>
+              <div class="phone-screen"><img src="./assets/screenshots/breaker_of_horses/boh_readerscreen_iliad_dual.png" alt="Breaker of Horses synchronized Greek and English reading view" width="1080" height="2162" /></div>
             </div>
           </div>
         </div>
@@ -314,6 +314,40 @@
           </article>
 
         </div>
+
+        <!-- Breaker of Horses · compact secondary reader -->
+        <article class="reader-card" aria-labelledby="breaker-card-title">
+          <div class="reader-card__copy">
+            <div class="app-card__head">
+              <img src="./assets/breaker_of_horses/breaker_of_horses_icon.png" alt="" class="app-card__icon" width="128" height="128" loading="lazy" decoding="async" />
+              <div>
+                <h3 class="app-card__name" id="breaker-card-title">Breaker of Horses</h3>
+                <div class="app-card__tags"><span class="app-tag">Free reader</span></div>
+              </div>
+            </div>
+            <h4 class="reader-card__headline">Read the epics that shaped the West.</h4>
+            <p class="reader-card__body">
+              The complete <i>Iliad</i> and <i>Odyssey</i> in Homeric Greek and three classic English translations.
+              Read one edition or compare two synchronized texts side by side.
+            </p>
+          </div>
+
+          <ul class="reader-card__features" aria-label="Breaker of Horses features">
+            <li>Greek and English</li>
+            <li>Synchronized editions</li>
+            <li>Fully offline</li>
+          </ul>
+
+          <div class="reader-card__visual">
+            <figure class="reader-card__phone">
+              <img src="./assets/screenshots/breaker_of_horses/boh_readerscreen_iliad_dual.png" alt="The Iliad in synchronized Greek and English panes in Breaker of Horses" width="1080" height="2162" loading="lazy" decoding="async" />
+            </figure>
+            <div class="reader-card__actions">
+              <a href="./breakerofhorses/" class="more-link">Learn more →</a>
+              <a href="https://play.google.com/store/apps/details?id=com.bhunt.breakerofhorses" target="_blank" rel="noopener" class="reader-card__get">Get it free</a>
+            </div>
+          </div>
+        </article>
       </section>
 
       <div class="divider"></div>
@@ -430,7 +464,7 @@
 
       <div class="divider"></div>
 
-      <!-- ============ 03 · ALL SIX APPS (closing CTA) ============ -->
+      <!-- ============ 03 · ALL APPS (closing CTA) ============ -->
       <section class="home-cta">
         <div class="sec-eyebrow" style="align-items:center; display:inline-flex;">
           <span class="sec-eyebrow__num">03</span>
@@ -449,6 +483,7 @@
           <a href="./guten/" aria-label="Guten"><img src="./icons/guten.png" alt="Guten" width="128" height="128" loading="lazy" decoding="async" /></a>
           <a href="./shelfscan/" aria-label="Shelf Scan"><img src="./icons/shelfscan.png" alt="Shelf Scan" width="128" height="128" loading="lazy" decoding="async" /></a>
           <a href="./keepclip/" aria-label="Keep Clip"><img src="./icons/keepclip.png" alt="Keep Clip" width="128" height="128" loading="lazy" decoding="async" /></a>
+          <a href="./breakerofhorses/" aria-label="Breaker of Horses"><img src="./assets/breaker_of_horses/breaker_of_horses_icon.png" alt="Breaker of Horses" width="128" height="128" loading="lazy" decoding="async" /></a>
           <a href="./trackanalysis/" aria-label="Track Analysis"><img src="./icons/trackanalysis.png" alt="Track Analysis" width="128" height="128" loading="lazy" decoding="async" /></a>
           <a href="./apps.html" aria-label="Curious Air"><img src="./icons/curiousair.png" alt="Curious Air" width="1024" height="1024" loading="lazy" decoding="async" /></a>
           <a href="./apps.html" aria-label="Loan It"><img src="./icons/loanit.png" alt="Loan It" width="128" height="128" loading="lazy" decoding="async" /></a>


### PR DESCRIPTION
## What changed

- Kept Guten, Shelf Scan, and Keep Clip unchanged as the three flagship cards
- Replaced only the fifth hero screenshot, the duplicate Guten reader screen, with Breaker of Horses
- Added a compact secondary Breaker of Horses card beneath the flagship row inside “Apps for readers”
- Added Breaker of Horses to the closing app-icon row, linked to its product page
- Used the existing `assets/breaker_of_horses/breaker_of_horses_icon.png` asset throughout
- Preserved the section support copy exactly
- Removed the fragile “Six Android apps” count from the homepage description and changed the internal closing-section comment to “All apps”

## Compact card

- Breaker icon and “Free reader” label
- “Read the epics that shaped the West.”
- Concise Greek-and-English reader description
- Greek and English, synchronized editions, and fully offline feature labels
- One restrained dual-pane screenshot
- Learn more and Get it free links

## Hierarchy

The new card uses the homepage’s existing warm-dark card system. It is shorter and visually quieter than the three flagship cards, so Breaker is present without receiving equal commercial emphasis. The closing icon row keeps the three flagships first, followed by Breaker and the utilities.

## Validation

- Parsed the HTML and JSON-LD successfully
- Confirmed the existing section support copy is unchanged
- Confirmed the existing Breaker icon asset resolves in both locations
- Confirmed the bottom-row icon links to `./breakerofhorses/`
- Checked for duplicate HTML IDs
- Rendered and inspected the full homepage and the card at 1440px desktop and 412px mobile widths
- Rebased onto the latest `new`
- Final diff is one commit changing only `index.html` and `assets/home.css`