### PR TITLE
Fix Breaker homepage card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200;0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&display=swap" rel="stylesheet" />
   <!-- Shared warm-dark editorial design system (same on apps.html) -->
-  <link rel="stylesheet" href="./assets/home.css" />
+  <link rel="stylesheet" href="./assets/home.css?v=20260715-breaker-card" />
 
   <script type="application/ld+json">
   {


### PR DESCRIPTION
## Problem

PR #102 deployed new Breaker of Horses markup to the homepage, but the stylesheet URL stayed unchanged. Browsers could therefore reuse a cached copy of `assets/home.css` from before the compact Breaker card rules existed. The result was the unstyled card and full-size screenshot shown on the live page.

## Fix

Version the homepage stylesheet request:

`./assets/home.css?v=20260715-breaker-card`

This forces browsers to fetch the current CSS while leaving the card markup and design unchanged.

## Validation

- Confirmed the compact `.reader-card` rules are present in `assets/home.css`
- Confirmed the homepage now requests the versioned stylesheet exactly once
- Rebased onto the latest `new`
- Final diff is one commit with a one-line change to `index.html`