### PR TITLE
Redesign Curious Air landing page for readability and clearer copy

### DIFF
--- a/assets/curiousair/landing.css
+++ b/assets/curiousair/landing.css
@@ -1,17 +1,649 @@
-@font-face{font-family:Geist;font-style:normal;font-weight:100 900;font-display:swap;src:url('../fonts/geist-latin.woff2') format('woff2')}
-:root{color-scheme:dark}
-.air-page{--bg:#061419;--bg2:#0a2027;--panel:#0c252d;--panel2:#102f38;--ink:#ecfbfc;--muted:rgba(236,251,252,.68);--faint:rgba(236,251,252,.43);--rule:rgba(155,235,242,.14);--cyan:#65e5ef;--cyan2:#26b8c9;--lime:#c9ef73;--amber:#f3c96b;--sans:Geist,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;--ulix-primary:var(--bg);--ulix-primary-dark:var(--bg);--ulix-accent:var(--cyan);--ulix-bg:var(--bg);--ulix-ink:var(--ink);min-height:100%;background:radial-gradient(circle at 84% 7%,rgba(38,184,201,.17),transparent 31rem),radial-gradient(circle at 3% 40%,rgba(101,229,239,.08),transparent 28rem),var(--bg);color:var(--ink);font-family:var(--sans);-webkit-font-smoothing:antialiased;overflow-x:hidden}
-.air-page *{box-sizing:border-box}.air-page a{color:inherit;text-decoration:none}.air-page img{display:block;max-width:100%}.air-page h1,.air-page h2,.air-page h3,.air-page p,.air-page ul,.air-page figure{margin:0}.air-page ul{padding:0;list-style:none}.air-page .site-header{background:rgba(6,20,25,.9);border-bottom-color:var(--rule);backdrop-filter:blur(16px)}.air-page .site-footer{background:#041015;border-top-color:var(--rule);color:var(--muted)}.air-page .site-footer__tag,.air-page .site-footer__copyright,.air-page .site-footer__links a{color:var(--muted)}.air-page .site-footer__brand-name,.air-page .site-footer__links a:hover{color:var(--ink)}.air-page .btn--primary{background:var(--cyan);color:#041216}
-.air-wrap{width:min(1180px,calc(100% - 40px));margin:0 auto}.eyebrow{display:inline-flex;align-items:center;gap:12px;font-size:11px;line-height:1;letter-spacing:.2em;text-transform:uppercase;font-weight:700;color:var(--cyan)}.eyebrow:before{content:"";width:24px;height:1px;background:currentColor;box-shadow:0 0 12px rgba(101,229,239,.7)}
-.air-hero{position:relative;min-height:760px;display:grid;align-items:center;border-bottom:1px solid var(--rule);overflow:hidden}.air-grid{position:absolute;inset:0;pointer-events:none;opacity:.23;background-image:linear-gradient(rgba(101,229,239,.12) 1px,transparent 1px),linear-gradient(90deg,rgba(101,229,239,.12) 1px,transparent 1px);background-size:44px 44px;mask-image:linear-gradient(to bottom,#000,transparent 89%)}.air-hero__inner{position:relative;z-index:2;display:grid;grid-template-columns:minmax(0,1.03fr) minmax(370px,.97fr);gap:62px;align-items:center;padding:96px 0 92px}.air-brand{display:flex;align-items:center;gap:15px;margin-bottom:28px}.air-brand img{width:66px;height:66px;border-radius:17px;box-shadow:0 16px 34px rgba(0,0,0,.34),0 0 0 1px rgba(255,255,255,.08)}.air-brand__name{font-size:17px;font-weight:750;letter-spacing:.02em}.air-brand__status{margin-top:4px;color:var(--muted);font-size:13px}.air-hero h1{max-width:720px;font-size:clamp(56px,7.2vw,98px);line-height:.91;letter-spacing:-.064em;font-weight:540}.air-hero h1 em{display:block;color:var(--cyan);font-style:normal;text-shadow:0 0 36px rgba(101,229,239,.15)}.air-hero__lede{max-width:650px;margin-top:30px;color:var(--muted);font-size:clamp(18px,2vw,22px);line-height:1.55;letter-spacing:-.015em}.air-actions{display:flex;flex-wrap:wrap;align-items:center;gap:14px;margin-top:36px}.air-play{display:inline-flex;align-items:center;gap:12px;padding:14px 21px;border-radius:999px;background:var(--cyan);color:#031115;font-weight:750;box-shadow:0 12px 32px rgba(38,184,201,.25);transition:transform .16s,box-shadow .16s}.air-play:hover{transform:translateY(-2px);box-shadow:0 16px 38px rgba(38,184,201,.34)}.air-play svg{width:19px;height:21px;flex:0 0 auto}.air-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:49px;padding:0 18px;border:1px solid var(--rule);border-radius:999px;color:var(--muted);font-weight:650;transition:.16s}.air-secondary:hover{color:var(--ink);border-color:rgba(101,229,239,.42);background:rgba(101,229,239,.06)}
-.air-hero__visual{position:relative;min-height:610px;display:grid;place-items:center}.orbit{position:absolute;border:1px solid rgba(101,229,239,.18);border-radius:50%;box-shadow:inset 0 0 32px rgba(101,229,239,.025)}.orbit--1{width:530px;height:530px}.orbit--2{width:390px;height:390px;border-style:dashed}.orbit--3{width:250px;height:250px}.orbit:after{content:"";position:absolute;width:9px;height:9px;border-radius:50%;top:50%;left:-5px;background:var(--cyan);box-shadow:0 0 18px rgba(101,229,239,.9)}.air-phone{position:relative;z-index:2;width:min(330px,78vw);aspect-ratio:1080/2124;padding:9px;border-radius:44px;background:linear-gradient(145deg,#24383d,#05090b 58%);box-shadow:0 44px 100px rgba(0,0,0,.5),0 8px 24px rgba(0,0,0,.35),0 0 0 1px rgba(255,255,255,.08);transform:rotate(2.2deg)}.air-phone:before{content:"";position:absolute;z-index:4;top:16px;left:50%;width:31%;height:18px;transform:translateX(-50%);border-radius:999px;background:#05090b}.air-phone img{width:100%;height:100%;border-radius:36px;object-fit:cover;object-position:top;background:#07161b}.blip{position:absolute;z-index:3;display:flex;align-items:center;gap:9px;min-width:150px;padding:11px 13px;border:1px solid rgba(101,229,239,.22);border-radius:10px;background:rgba(7,28,34,.9);box-shadow:0 16px 38px rgba(0,0,0,.28);backdrop-filter:blur(12px);color:var(--muted);font-size:11px;letter-spacing:.11em;text-transform:uppercase}.blip:before{content:"";width:7px;height:7px;border-radius:50%;background:var(--lime);box-shadow:0 0 12px rgba(201,239,115,.75)}.blip--wifi{top:19%;right:-2%}.blip--ble{bottom:24%;left:-5%}.blip--gnss{bottom:11%;right:1%}
-.air-principles{border-bottom:1px solid var(--rule);background:rgba(4,16,21,.42)}.principles-grid{display:grid;grid-template-columns:repeat(4,1fr)}.principle{padding:25px 24px;border-right:1px solid var(--rule)}.principle:last-child{border-right:0}.principle__code{display:block;margin-bottom:9px;color:var(--cyan);font-size:10px;font-weight:700;letter-spacing:.16em;text-transform:uppercase}.principle h3{font-size:16px;font-weight:680}.principle p{margin-top:6px;color:var(--faint);font-size:13px;line-height:1.5}
-.air-section{padding:112px 0;border-bottom:1px solid var(--rule)}.section-head{display:grid;grid-template-columns:1fr minmax(280px,430px);gap:60px;align-items:end;margin-bottom:54px}.section-head h2{margin-top:18px;max-width:780px;font-size:clamp(38px,5vw,68px);line-height:1;letter-spacing:-.048em;font-weight:530}.section-intro{color:var(--muted);font-size:17px;line-height:1.65}
-.instrument-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}.instrument-card{position:relative;min-height:310px;padding:27px;border:1px solid var(--rule);border-radius:18px;background:linear-gradient(180deg,rgba(16,47,56,.9),rgba(8,29,35,.84));overflow:hidden;box-shadow:0 20px 50px rgba(0,0,0,.18)}.instrument-card:before{content:"";position:absolute;inset:0;background-image:linear-gradient(rgba(101,229,239,.06) 1px,transparent 1px),linear-gradient(90deg,rgba(101,229,239,.06) 1px,transparent 1px);background-size:28px 28px;mask-image:linear-gradient(to bottom,#000,transparent 80%)}.instrument-card>*{position:relative;z-index:1}.instrument-card__top{display:flex;align-items:center;justify-content:space-between}.instrument-card__code{font-size:10px;letter-spacing:.17em;text-transform:uppercase;color:var(--cyan);font-weight:750}.live{display:inline-flex;align-items:center;gap:7px;color:var(--lime);font-size:9px;letter-spacing:.14em;text-transform:uppercase}.live:before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 10px currentColor}.instrument-card h3{margin-top:58px;font-size:31px;letter-spacing:-.035em}.instrument-card p{margin-top:12px;color:var(--muted);font-size:15px;line-height:1.58}.instrument-card ul{display:flex;flex-wrap:wrap;gap:7px;margin-top:24px}.instrument-card li{padding:7px 9px;border:1px solid rgba(101,229,239,.14);border-radius:6px;color:var(--faint);font-size:10px;letter-spacing:.06em;text-transform:uppercase}
-.showcase{display:grid;gap:26px}.showcase-row{display:grid;grid-template-columns:minmax(0,.85fr) minmax(440px,1.15fr);min-height:590px;border:1px solid var(--rule);border-radius:22px;background:rgba(10,32,39,.76);overflow:hidden}.showcase-row:nth-child(even){grid-template-columns:minmax(440px,1.15fr) minmax(0,.85fr)}.showcase-row:nth-child(even) .showcase-copy{order:2}.showcase-row:nth-child(even) .showcase-art{order:1}.showcase-copy{display:flex;flex-direction:column;justify-content:center;padding:54px}.showcase-label{margin-bottom:20px;color:var(--cyan);font-size:10px;font-weight:750;letter-spacing:.18em;text-transform:uppercase}.showcase-copy h3{max-width:500px;font-size:clamp(34px,4vw,54px);line-height:1.02;letter-spacing:-.045em;font-weight:540}.showcase-copy p{margin-top:20px;color:var(--muted);font-size:16px;line-height:1.66}.showcase-copy ul{display:grid;gap:10px;margin-top:27px}.showcase-copy li{position:relative;padding-left:20px;color:var(--muted);font-size:14px;line-height:1.45}.showcase-copy li:before{content:"";position:absolute;left:0;top:.55em;width:7px;height:7px;border:1px solid var(--cyan);transform:rotate(45deg)}.showcase-art{position:relative;min-height:590px;display:flex;align-items:flex-end;justify-content:center;padding:50px 34px 0;background:radial-gradient(circle at 50% 53%,rgba(38,184,201,.18),transparent 44%),rgba(4,16,21,.34);overflow:hidden}.showcase-art:before{content:"";position:absolute;inset:0;background-image:linear-gradient(rgba(101,229,239,.07) 1px,transparent 1px),linear-gradient(90deg,rgba(101,229,239,.07) 1px,transparent 1px);background-size:38px 38px}.shot{position:relative;width:245px;border:7px solid #081014;border-bottom:0;border-radius:35px 35px 0 0;box-shadow:0 24px 62px rgba(0,0,0,.46);background:#061419}.shot--rear{z-index:1;margin-right:-38px;transform:translateY(48px) rotate(-4deg);opacity:.7}.shot--front{z-index:2;transform:rotate(2deg)}
-.capability{display:grid;grid-template-columns:1fr 390px;gap:76px;align-items:center;padding:54px 64px;border:1px solid var(--rule);border-radius:22px;background:linear-gradient(135deg,rgba(16,47,56,.9),rgba(7,26,32,.85));overflow:hidden}.capability h3{margin-top:18px;max-width:650px;font-size:clamp(38px,5vw,66px);line-height:1.02;letter-spacing:-.05em;font-weight:530}.capability p{margin-top:22px;max-width:680px;color:var(--muted);font-size:17px;line-height:1.65}.cap-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:28px}.cap-pills li{padding:8px 10px;border:1px solid rgba(101,229,239,.18);border-radius:7px;color:var(--faint);font-size:10px;letter-spacing:.07em;text-transform:uppercase}.cap-image{align-self:end;width:310px;margin:0 auto -120px;border:8px solid #071014;border-radius:38px;box-shadow:0 28px 70px rgba(0,0,0,.45);overflow:hidden}
-.pro-block{display:grid;grid-template-columns:1fr 370px;gap:62px;align-items:center;padding:55px 62px;border:1px solid rgba(243,201,107,.2);border-radius:22px;background:radial-gradient(circle at 83% 25%,rgba(243,201,107,.12),transparent 27rem),#0b2026;overflow:hidden}.pro-block .eyebrow{color:var(--amber)}.pro-copy h3{margin-top:18px;max-width:670px;font-size:clamp(38px,5vw,65px);line-height:1.01;letter-spacing:-.048em;font-weight:530}.pro-copy p{margin-top:22px;max-width:690px;color:var(--muted);font-size:17px;line-height:1.65}.pro-facts{display:flex;flex-wrap:wrap;gap:8px;margin-top:27px}.pro-facts span{padding:8px 10px;border:1px solid rgba(243,201,107,.2);border-radius:7px;color:rgba(243,201,107,.77);font-size:10px;letter-spacing:.07em;text-transform:uppercase}.pro-image{align-self:end;width:290px;margin:0 auto -120px;border:8px solid #071014;border-radius:38px;box-shadow:0 28px 70px rgba(0,0,0,.45);overflow:hidden}
-.trust-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px}.trust-card{padding:38px;border:1px solid var(--rule);border-radius:18px;background:rgba(10,32,39,.7)}.trust-card--labs{border-color:rgba(243,201,107,.2)}.trust-label{color:var(--cyan);font-size:10px;font-weight:750;letter-spacing:.18em;text-transform:uppercase}.trust-card--labs .trust-label{color:var(--amber)}.trust-card h3{margin-top:26px;font-size:30px;letter-spacing:-.035em}.trust-card p{margin-top:15px;color:var(--muted);font-size:15px;line-height:1.68}.air-final{padding:126px 0;text-align:center;background:radial-gradient(circle at 50% 55%,rgba(38,184,201,.17),transparent 28rem)}.air-final .eyebrow{justify-content:center}.air-final h2{max-width:850px;margin:24px auto 0;font-size:clamp(46px,7vw,86px);line-height:.97;letter-spacing:-.058em;font-weight:520}.air-final p{margin-top:22px;color:var(--muted);font-size:19px}.air-final .air-play{margin-top:32px}
-@media(max-width:980px){.air-hero__inner{grid-template-columns:1fr;padding-top:76px}.air-hero__visual{min-height:570px}.principles-grid{grid-template-columns:1fr 1fr}.principle:nth-child(2){border-right:0}.principle:nth-child(-n+2){border-bottom:1px solid var(--rule)}.section-head{grid-template-columns:1fr;gap:24px}.instrument-grid{grid-template-columns:1fr}.instrument-card{min-height:260px}.instrument-card h3{margin-top:38px}.showcase-row,.showcase-row:nth-child(even){grid-template-columns:1fr}.showcase-row:nth-child(even) .showcase-copy,.showcase-row:nth-child(even) .showcase-art{order:initial}.capability,.pro-block{grid-template-columns:1fr;padding-bottom:0}.cap-image,.pro-image{margin-bottom:-100px}.trust-grid{grid-template-columns:1fr}}
-@media(max-width:680px){.air-wrap{width:min(100% - 28px,1180px)}.air-hero__inner{gap:36px;padding:62px 0 70px}.air-hero h1{font-size:clamp(51px,16vw,72px)}.air-hero__visual{min-height:490px}.orbit--1{width:420px;height:420px}.orbit--2{width:310px;height:310px}.orbit--3{width:200px;height:200px}.air-phone{width:260px;border-radius:36px}.air-phone img{border-radius:29px}.blip{display:none}.principles-grid{grid-template-columns:1fr}.principle{border-right:0;border-bottom:1px solid var(--rule)}.principle:last-child{border-bottom:0}.air-section{padding:82px 0}.section-head{margin-bottom:36px}.showcase-copy{padding:38px 27px}.showcase-art{min-height:500px;padding:42px 12px 0}.shot{width:205px}.shot--rear{margin-right:-70px}.capability,.pro-block{padding:39px 26px 0;gap:38px}.cap-image,.pro-image{width:245px}.trust-card{padding:29px}.air-final{padding:92px 0}}
-@media(prefers-reduced-motion:reduce){.air-play{transition:none}.air-play:hover{transform:none}}
+/* ==========================================================================
+   Curious Air — landing page styles
+   --------------------------------------------------------------------------
+   Loads after ulix.css. The page is a dark "signal console" that borrows
+   its palette and monospace readouts from the app itself. Organised:
+     1. Tokens + page base (incl. overrides of ulix.css defaults)
+     2. Shared primitives (wrap, eyebrow, section heads, pills, buttons)
+     3. Hero
+     4. Principles band
+     5. Instrument cards
+     6. Screenshot showcase rows
+     7. Capability + Pro bands
+     8. Trust cards + final CTA
+     9. Footer adjustments
+    10. Responsive
+   ========================================================================== */
+
+
+/* 1. Tokens + page base
+   ========================================================================== */
+@font-face {
+  font-family: Geist;
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url('../fonts/geist-latin.woff2') format('woff2');
+}
+
+:root { color-scheme: dark; }
+
+.air-page {
+  /* Palette sampled from the app: deep navy console, cyan primary,
+     per-instrument accents (orange Wi-Fi, green BLE, violet NFC, amber Pro). */
+  --bg: #050d13;
+  --bg-raise: #0a1922;
+  --panel: #0d202b;
+  --ink: #eaf6f8;
+  --muted: #a7c3cd;          /* solid colours, not low-alpha white — keeps AA contrast */
+  --soft: #7f9ba6;
+  --rule: rgba(151, 214, 226, 0.16);
+  --cyan: #4fd9e7;
+  --cyan-deep: #1fa9bc;
+  --green: #79e29b;
+  --orange: #f0a868;
+  --violet: #b99cf2;
+  --amber: #efc368;
+  --sans: Geist, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Consolas, monospace;
+
+  /* Retint shared header/footer chrome without touching heading colours. */
+  --ulix-accent: var(--cyan);
+
+  min-height: 100%;
+  background:
+    radial-gradient(circle at 85% 5%, rgba(31, 169, 188, 0.14), transparent 30rem),
+    radial-gradient(circle at 0% 45%, rgba(79, 217, 231, 0.06), transparent 26rem),
+    var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+.air-page * { box-sizing: border-box; }
+.air-page a { color: inherit; text-decoration: none; }
+.air-page img { display: block; max-width: 100%; }
+.air-page h1, .air-page h2, .air-page h3,
+.air-page p, .air-page ul, .air-page figure { margin: 0; }
+.air-page ul { padding: 0; list-style: none; }
+
+/* ulix.css paints h1–h4 with --ulix-primary (navy) — invisible on a dark
+   page. State the heading colour explicitly. */
+.air-page h1, .air-page h2, .air-page h3, .air-page h4 { color: var(--ink); }
+
+.air-page :focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
+
+/* Shared header / footer, retinted */
+.air-page .site-header {
+  background: rgba(5, 13, 19, 0.88);
+  border-bottom-color: var(--rule);
+  backdrop-filter: blur(14px);
+}
+.air-page .btn--primary {
+  background: var(--cyan);
+  border-color: var(--cyan);
+  color: #04141a;
+}
+.air-page .site-footer { background: #03090d; border-top-color: var(--rule); color: var(--muted); }
+.air-page .site-footer__copyright,
+.air-page .site-footer__links a,
+.air-page .newsletter__label { color: var(--muted); }
+.air-page .site-footer__links a:hover { color: var(--ink); }
+
+
+/* 2. Shared primitives
+   ========================================================================== */
+.air-wrap { width: min(1160px, 100% - 44px); margin: 0 auto; }
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cyan);
+}
+.eyebrow::before { content: "//"; opacity: 0.65; }
+
+.air-section { padding: 104px 0; border-bottom: 1px solid var(--rule); }
+
+/* ulix.css makes .section-head a space-between flex row — reset to a stack */
+.section-head { display: block; max-width: 780px; margin-bottom: 56px; }
+.section-head h2 {
+  margin-top: 16px;
+  font-size: clamp(32px, 4.4vw, 52px);
+  line-height: 1.06;
+  letter-spacing: -0.025em;
+  font-weight: 620;
+}
+.section-intro {
+  margin-top: 18px;
+  max-width: 640px;
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+/* Small uppercase chips used for feature lists */
+.pill-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.pill-row li, .pill-row span {
+  padding: 7px 11px;
+  border: 1px solid var(--rule);
+  border-radius: 7px;
+  background: rgba(79, 217, 231, 0.05);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* Primary pill CTA */
+.air-play {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 15px 24px;
+  border-radius: 999px;
+  background: var(--cyan);
+  color: #04141a;
+  font-size: 16px;
+  font-weight: 640;
+  box-shadow: 0 12px 32px rgba(31, 169, 188, 0.28);
+  transition: transform 0.16s, box-shadow 0.16s;
+}
+.air-play:hover { transform: translateY(-2px); box-shadow: 0 16px 38px rgba(31, 169, 188, 0.38); }
+.air-play svg { width: 18px; height: 20px; flex: 0 0 auto; }
+
+.air-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 51px;
+  padding: 0 20px;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 15px;
+  font-weight: 560;
+  transition: color 0.16s, border-color 0.16s, background 0.16s;
+}
+.air-secondary:hover {
+  color: var(--ink);
+  border-color: rgba(79, 217, 231, 0.45);
+  background: rgba(79, 217, 231, 0.07);
+}
+
+
+/* 3. Hero
+   ========================================================================== */
+.air-hero { position: relative; border-bottom: 1px solid var(--rule); overflow: hidden; }
+
+.air-grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.2;
+  background-image:
+    linear-gradient(rgba(79, 217, 231, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(79, 217, 231, 0.12) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, #000, transparent 88%);
+}
+
+.air-hero__inner {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr);
+  gap: 56px;
+  align-items: center;
+  padding: 88px 0 84px;
+}
+
+.air-brand { display: flex; align-items: center; gap: 15px; margin-bottom: 30px; }
+.air-brand img {
+  width: 62px;
+  height: 62px;
+  border-radius: 16px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.09);
+}
+.air-brand__name { font-size: 18px; font-weight: 660; letter-spacing: 0.01em; }
+.air-brand__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 6px;
+  padding: 4px 10px;
+  border: 1px solid rgba(121, 226, 155, 0.35);
+  border-radius: 999px;
+  color: var(--green);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+.air-brand__status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.air-hero h1 {
+  max-width: 640px;
+  font-size: clamp(42px, 6.4vw, 78px);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  font-weight: 640;
+}
+.air-hero h1 em { color: var(--cyan); font-style: normal; }
+
+.air-hero__lede {
+  max-width: 600px;
+  margin-top: 26px;
+  color: var(--muted);
+  font-size: clamp(17px, 1.8vw, 20px);
+  line-height: 1.6;
+}
+
+.air-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; margin-top: 36px; }
+
+.hero-readout {
+  margin-top: 34px;
+  color: var(--soft);
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.hero-readout b { color: var(--cyan); font-weight: 400; }
+
+/* Hero visual: phone in a device shell, two floating readout cards */
+.air-hero__visual { position: relative; min-height: 620px; display: grid; place-items: center; }
+
+.air-ring {
+  position: absolute;
+  border: 1px solid rgba(79, 217, 231, 0.16);
+  border-radius: 50%;
+}
+.air-ring--1 { width: 540px; height: 540px; }
+.air-ring--2 { width: 380px; height: 380px; border-style: dashed; opacity: 0.8; }
+
+.air-phone {
+  position: relative;
+  z-index: 2;
+  width: min(320px, 76vw);
+  aspect-ratio: 1080 / 2124;
+  padding: 9px;
+  border-radius: 44px;
+  background: linear-gradient(145deg, #223740, #05090c 58%);
+  box-shadow:
+    0 44px 100px rgba(0, 0, 0, 0.5),
+    0 8px 24px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  transform: rotate(1.6deg);
+}
+.air-phone img { width: 100%; height: 100%; border-radius: 36px; object-fit: cover; object-position: top; background: #071219; }
+
+.readout {
+  position: absolute;
+  z-index: 3;
+  min-width: 148px;
+  padding: 12px 14px;
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  background: rgba(8, 22, 30, 0.92);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(10px);
+  font-family: var(--mono);
+}
+.readout__label { font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--soft); }
+.readout__value { margin-top: 5px; font-size: 17px; color: var(--ink); }
+.readout--wifi { top: 17%; right: -1%; }
+.readout--wifi .readout__value { color: var(--orange); }
+.readout--gnss { bottom: 15%; left: -3%; }
+.readout--gnss .readout__value { color: var(--green); }
+.readout svg { display: block; margin-top: 8px; width: 100%; height: 22px; }
+
+
+/* 4. Principles band
+   ========================================================================== */
+.air-principles { border-bottom: 1px solid var(--rule); background: rgba(3, 11, 16, 0.5); }
+.principles-grid { display: grid; grid-template-columns: repeat(4, 1fr); }
+.principle { padding: 30px 26px; border-right: 1px solid var(--rule); }
+.principle:last-child { border-right: 0; }
+.principle__code {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.principle h3 { font-size: 17px; font-weight: 640; }
+.principle p { margin-top: 8px; color: var(--muted); font-size: 14px; line-height: 1.55; }
+
+
+/* 5. Instrument cards
+   ========================================================================== */
+.instrument-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+
+.instrument-card {
+  --edge: var(--cyan);
+  position: relative;
+  padding: 30px 30px 30px 34px;
+  border: 1px solid var(--rule);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(13, 32, 43, 0.92), rgba(7, 21, 29, 0.85));
+  overflow: hidden;
+}
+.instrument-card::before {
+  /* coloured left edge, echoing the cards on the app home screen */
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 18px;
+  bottom: 18px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--edge);
+  box-shadow: 0 0 14px var(--edge);
+}
+.instrument-card--position { --edge: var(--violet); }
+.instrument-card--environment { --edge: var(--green); }
+.instrument-card--labs { --edge: var(--amber); }
+
+.instrument-card__top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.instrument-card__code {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--edge);
+}
+.tag-live, .tag-labs {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+.tag-labs { color: var(--amber); }
+.tag-live::before, .tag-labs::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 9px currentColor;
+}
+
+.instrument-card h3 { margin-top: 26px; font-size: 26px; letter-spacing: -0.02em; font-weight: 620; }
+.instrument-card p { margin-top: 12px; max-width: 460px; color: var(--muted); font-size: 15px; line-height: 1.6; }
+.instrument-card .pill-row { margin-top: 22px; }
+
+
+/* 6. Screenshot showcase rows
+   ========================================================================== */
+.showcase { display: grid; gap: 26px; }
+
+.showcase-row {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
+  min-height: 560px;
+  border: 1px solid var(--rule);
+  border-radius: 22px;
+  background: rgba(9, 26, 35, 0.72);
+  overflow: hidden;
+}
+.showcase-row:nth-child(even) { grid-template-columns: minmax(420px, 1.1fr) minmax(0, 0.9fr); }
+.showcase-row:nth-child(even) .showcase-copy { order: 2; }
+.showcase-row:nth-child(even) .showcase-art { order: 1; }
+
+.showcase-copy { display: flex; flex-direction: column; justify-content: center; padding: 52px; }
+.showcase-label {
+  margin-bottom: 18px;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.showcase-copy h3 {
+  max-width: 460px;
+  font-size: clamp(28px, 3.4vw, 42px);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  font-weight: 620;
+}
+.showcase-copy p { margin-top: 18px; max-width: 480px; color: var(--muted); font-size: 16px; line-height: 1.65; }
+.showcase-copy ul { display: grid; gap: 12px; margin-top: 26px; }
+.showcase-copy li {
+  position: relative;
+  padding-left: 22px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.showcase-copy li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.5em;
+  width: 7px;
+  height: 7px;
+  border: 1px solid var(--cyan);
+  transform: rotate(45deg);
+}
+
+.showcase-art {
+  position: relative;
+  min-height: 560px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 48px 34px 0;
+  background:
+    radial-gradient(circle at 50% 55%, rgba(31, 169, 188, 0.16), transparent 46%),
+    rgba(3, 11, 16, 0.35);
+  overflow: hidden;
+}
+.shot {
+  position: relative;
+  width: 240px;
+  border: 7px solid #081016;
+  border-bottom: 0;
+  border-radius: 34px 34px 0 0;
+  box-shadow: 0 24px 62px rgba(0, 0, 0, 0.46);
+  background: var(--bg);
+}
+.shot--rear { z-index: 1; margin-right: -36px; transform: translateY(46px) rotate(-4deg); opacity: 0.75; }
+.shot--front { z-index: 2; transform: rotate(2deg); }
+
+
+/* 7. Capability + Pro bands
+   ========================================================================== */
+.capability {
+  display: grid;
+  grid-template-columns: 1fr 370px;
+  gap: 72px;
+  align-items: center;
+  padding: 56px 62px 0;
+  border: 1px solid var(--rule);
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(13, 32, 43, 0.92), rgba(6, 18, 25, 0.85));
+  overflow: hidden;
+}
+.capability h3 {
+  margin-top: 16px;
+  max-width: 560px;
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  font-weight: 620;
+}
+.capability p { margin-top: 20px; max-width: 620px; color: var(--muted); font-size: 16px; line-height: 1.65; }
+.capability .pill-row { margin-top: 26px; padding-bottom: 56px; }
+.cap-image {
+  align-self: end;
+  width: 300px;
+  margin: 0 auto -110px;
+  border: 8px solid #081016;
+  border-radius: 38px;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.pro-block {
+  display: grid;
+  grid-template-columns: 1fr 350px;
+  gap: 62px;
+  align-items: center;
+  padding: 56px 62px 0;
+  border: 1px solid rgba(239, 195, 104, 0.28);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 85% 20%, rgba(239, 195, 104, 0.1), transparent 26rem),
+    #0a1c24;
+  overflow: hidden;
+}
+.pro-block .eyebrow { color: var(--amber); }
+.pro-copy h3 {
+  margin-top: 16px;
+  max-width: 600px;
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  font-weight: 620;
+}
+.pro-copy p { margin-top: 20px; max-width: 620px; color: var(--muted); font-size: 16px; line-height: 1.65; }
+.pro-copy .pill-row { margin-top: 26px; padding-bottom: 56px; }
+.pro-copy .pill-row span {
+  border-color: rgba(239, 195, 104, 0.3);
+  background: rgba(239, 195, 104, 0.06);
+  color: var(--amber);
+}
+.pro-image {
+  align-self: end;
+  width: 285px;
+  margin: 0 auto -110px;
+  border: 8px solid #081016;
+  border-radius: 38px;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+
+/* 8. Trust cards + final CTA
+   ========================================================================== */
+.trust-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.trust-card {
+  padding: 38px;
+  border: 1px solid var(--rule);
+  border-radius: 18px;
+  background: rgba(9, 26, 35, 0.7);
+}
+.trust-card--labs { border-color: rgba(239, 195, 104, 0.28); }
+.trust-label {
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.trust-card--labs .trust-label { color: var(--amber); }
+.trust-card h3 { margin-top: 20px; font-size: 25px; letter-spacing: -0.02em; font-weight: 620; }
+.trust-card p { margin-top: 14px; color: var(--muted); font-size: 15px; line-height: 1.68; }
+
+.air-final {
+  padding: 120px 0;
+  text-align: center;
+  background: radial-gradient(circle at 50% 55%, rgba(31, 169, 188, 0.15), transparent 28rem);
+}
+.air-final .eyebrow { justify-content: center; }
+.air-final h2 {
+  max-width: 760px;
+  margin: 22px auto 0;
+  font-size: clamp(36px, 5.6vw, 66px);
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+  font-weight: 630;
+}
+.air-final p { max-width: 560px; margin: 20px auto 0; color: var(--muted); font-size: 18px; line-height: 1.6; }
+.air-final .air-play { margin-top: 34px; }
+
+
+/* 9. Footer adjustments
+   ========================================================================== */
+.air-page .footer-credo {
+  margin: 0 0 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  text-align: center;
+  color: var(--soft);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+.air-page .footer-credo b { color: var(--ink); font-weight: 500; }
+.air-page .footer-credo .sep { color: var(--cyan); padding: 0 6px; }
+
+
+/* 10. Responsive
+   ========================================================================== */
+@media (max-width: 980px) {
+  .air-hero__inner { grid-template-columns: 1fr; padding-top: 68px; gap: 48px; }
+  .air-hero__visual { min-height: 560px; }
+  .principles-grid { grid-template-columns: 1fr 1fr; }
+  .principle:nth-child(2) { border-right: 0; }
+  .principle:nth-child(-n+2) { border-bottom: 1px solid var(--rule); }
+  .instrument-grid { grid-template-columns: 1fr; }
+  .showcase-row, .showcase-row:nth-child(even) { grid-template-columns: 1fr; }
+  .showcase-row:nth-child(even) .showcase-copy,
+  .showcase-row:nth-child(even) .showcase-art { order: initial; }
+  .capability, .pro-block { grid-template-columns: 1fr; padding-bottom: 0; }
+  .capability .pill-row, .pro-copy .pill-row { padding-bottom: 0; }
+  .cap-image, .pro-image { margin-top: 44px; margin-bottom: -100px; }
+  .trust-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 680px) {
+  .air-wrap { width: min(100% - 32px, 1160px); }
+  .air-hero__inner { gap: 40px; padding: 56px 0 64px; }
+  .air-hero__visual { min-height: 470px; }
+  .air-ring--1 { width: 400px; height: 400px; }
+  .air-ring--2 { width: 290px; height: 290px; }
+  .air-phone { width: 250px; border-radius: 36px; }
+  .air-phone img { border-radius: 29px; }
+  .readout { min-width: 128px; padding: 10px 12px; }
+  .readout--wifi { right: -4px; }
+  .readout--gnss { left: -4px; }
+  .principles-grid { grid-template-columns: 1fr; }
+  .principle { border-right: 0; border-bottom: 1px solid var(--rule); }
+  .principle:last-child { border-bottom: 0; }
+  .air-section { padding: 76px 0; }
+  .section-head { margin-bottom: 40px; }
+  .showcase-copy { padding: 36px 26px; }
+  .showcase-art { min-height: 480px; padding: 40px 12px 0; }
+  .shot { width: 200px; }
+  .shot--rear { margin-right: -66px; }
+  .capability, .pro-block { padding: 38px 26px 0; gap: 36px; }
+  .cap-image, .pro-image { width: 240px; }
+  .trust-card { padding: 28px; }
+  .air-final { padding: 88px 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .air-play { transition: none; }
+  .air-play:hover { transform: none; }
+}

--- a/curiousair/index.html
+++ b/curiousair/index.html
@@ -4,26 +4,26 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Curious Air — See What’s Broadcasting Around You</title>
-  <meta name="description" content="Curious Air turns your Android phone into a privacy-first signal console for Wi-Fi, Bluetooth, cellular, satellites, sensors, NFC, audio, and more. Now in Google Play testing." />
+  <meta name="description" content="Curious Air turns your Android phone into a set of instruments for the signals around you: Wi-Fi, Bluetooth, cellular, satellites, sensors, NFC, and audio. No account, and your readings stay on your device. Now in Google Play testing." />
   <link rel="canonical" href="https://ulix.app/curiousair/" />
-  <meta name="theme-color" content="#061419" />
+  <meta name="theme-color" content="#050d13" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Ulix" />
   <meta property="og:title" content="Curious Air — See What’s Broadcasting" />
-  <meta property="og:description" content="A privacy-first signal explorer for Wi-Fi, Bluetooth, cellular, satellites, sensors, NFC, audio, and more." />
+  <meta property="og:description" content="A signal explorer for Android: Wi-Fi, Bluetooth, cellular, satellites, sensors, NFC, and audio. No account — readings stay on your device." />
   <meta property="og:url" content="https://ulix.app/curiousair/" />
   <meta property="og:image" content="https://ulix.app/assets/curiousair/curious-air-feature-image.png" />
   <meta property="og:image:alt" content="Curious Air signal explorer for Android" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Curious Air — See What’s Broadcasting" />
-  <meta name="twitter:description" content="Turn your Android phone into a privacy-first signal console." />
+  <meta name="twitter:description" content="Turn your Android phone into a set of instruments for the signals around you." />
   <meta name="twitter:image" content="https://ulix.app/assets/curiousair/curious-air-feature-image.png" />
   <link rel="icon" href="/icons/favicon.ico" sizes="any" />
   <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
   <link rel="stylesheet" href="../assets/ulix.css" />
-  <link rel="stylesheet" href="../assets/curiousair/landing.css" />
+  <link rel="stylesheet" href="../assets/curiousair/landing.css?v=2" />
   <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/geist-latin.woff2" crossorigin />
   <script type="application/ld+json">
   {
@@ -115,122 +115,218 @@
   </div>
 
   <main id="main">
+
+    <!-- Hero -->
     <section class="air-hero">
-      <div class="air-grid"></div>
+      <div class="air-grid" aria-hidden="true"></div>
       <div class="air-wrap air-hero__inner">
         <div>
           <div class="air-brand">
             <img src="../icons/curiousair.png" alt="Curious Air app icon" width="1024" height="1024" />
-            <div><div class="air-brand__name">Curious Air</div><div class="air-brand__status">Now in Google Play testing</div></div>
+            <div>
+              <div class="air-brand__name">Curious Air</div>
+              <div class="air-brand__status">Now testing on Google Play</div>
+            </div>
           </div>
-          <span class="eyebrow">Privacy-first signal explorer</span>
-          <h1>See what’s <em>broadcasting.</em></h1>
-          <p class="air-hero__lede">Turn your Android phone into a field console for the signals and sensors already around you: Wi-Fi, Bluetooth, cellular, satellites, NFC, light, motion, magnetic fields, audio, and more.</p>
+          <h1>See what’s <em>broadcasting</em> around you.</h1>
+          <p class="air-hero__lede">Your phone already hears more than it shows you — Wi-Fi, Bluetooth, satellites, magnetic fields, even the hum of AC power. Curious Air turns it into a set of instruments for looking. No account, and your readings stay on your device.</p>
           <div class="air-actions">
             <a href="https://play.google.com/store/apps/details?id=com.bhunt.curiousair" target="_blank" rel="noopener" class="air-play">
               <svg viewBox="0 0 20 22" fill="none" aria-hidden="true"><path d="M1 1.5v19l10-9.5L1 1.5z" fill="currentColor"/><path d="M11 11l5-3c1.2-.7 1.2-2.3 0-3L11 2.1V19.9l5-2.9c1.2-.7 1.2-2.3 0-3L11 11z" fill="currentColor" opacity=".45"/></svg>
               Join the Google Play test
             </a>
-            <a href="#instruments" class="air-secondary">Explore the instruments ↓</a>
+            <a href="#instruments" class="air-secondary">See the instruments ↓</a>
           </div>
+          <p class="hero-readout" aria-hidden="true">Live · <b>166 signals</b> · 114 Wi-Fi · 52 BLE · 23 sats</p>
         </div>
-        <div class="air-hero__visual" aria-label="Curious Air app preview">
-          <div class="orbit orbit--1"></div><div class="orbit orbit--2"></div><div class="orbit orbit--3"></div>
-          <div class="blip blip--wifi">Wi-Fi spectrum</div><div class="blip blip--ble">BLE radar</div><div class="blip blip--gnss">GNSS sky map</div>
+        <div class="air-hero__visual">
+          <div class="air-ring air-ring--1" aria-hidden="true"></div>
+          <div class="air-ring air-ring--2" aria-hidden="true"></div>
+          <div class="readout readout--wifi" aria-hidden="true">
+            <div class="readout__label">Wi-Fi</div>
+            <div class="readout__value">−54 dBm</div>
+            <svg viewBox="0 0 120 22" preserveAspectRatio="none"><polyline points="0,14 18,13 34,15 48,9 62,11 78,6 94,10 108,5 120,8" fill="none" stroke="#f0a868" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="readout readout--gnss" aria-hidden="true">
+            <div class="readout__label">GNSS</div>
+            <div class="readout__value">23 sats</div>
+          </div>
           <figure class="air-phone"><img src="../assets/screenshots/curiousair/curious-air-mainscreen-1.png" alt="Curious Air home screen showing radio, position, environment, and labs instruments" width="1080" height="2124" /></figure>
         </div>
       </div>
     </section>
 
+    <!-- Principles -->
     <section class="air-principles" aria-label="Product principles">
       <div class="air-wrap principles-grid">
-        <article class="principle"><span class="principle__code">01 · Local first</span><h3>Your phone does the looking.</h3><p>Signal data is not sent to Ulix unless you export or share it.</p></article>
-        <article class="principle"><span class="principle__code">02 · Permission aware</span><h3>You choose every instrument.</h3><p>Grant only the radio and sensor access you want to use.</p></article>
-        <article class="principle"><span class="principle__code">03 · No account</span><h3>Open it and explore.</h3><p>No Curious Air login, profile, feed, or cloud dashboard.</p></article>
-        <article class="principle"><span class="principle__code">04 · Free + Pro</span><h3>Pay once for logging.</h3><p>Core exploration is free. Pro adds timed CSV observations.</p></article>
+        <article class="principle"><span class="principle__code">01 · Local-first</span><h3>Readings stay on your phone.</h3><p>Nothing you scan is uploaded to Ulix. Data leaves your device only when you export a file yourself.</p></article>
+        <article class="principle"><span class="principle__code">02 · Permission-aware</span><h3>Every instrument asks first.</h3><p>Grant only the radio and sensor access you want. Deny a permission and the rest of the app keeps working.</p></article>
+        <article class="principle"><span class="principle__code">03 · No account</span><h3>Open it and start looking.</h3><p>No sign-up, no profile, no ads, no cloud dashboard. Just the instruments.</p></article>
+        <article class="principle"><span class="principle__code">04 · Pay once, optional</span><h3>Everything live is free.</h3><p>A one-time Pro unlock adds timed logging and CSV export. No subscription.</p></article>
       </div>
     </section>
 
+    <!-- Instruments -->
     <section class="air-section" id="instruments">
       <div class="air-wrap">
         <div class="section-head">
-          <div><span class="eyebrow">A pocket field console</span><h2>The invisible world, arranged into instruments.</h2></div>
-          <p class="section-intro">Curious Air does not collapse every reading into one mysterious score. Each radio, sensor, and experimental method gets its own console, its own units, and its own limits.</p>
+          <span class="eyebrow">The instruments</span>
+          <h2>One console per signal.</h2>
+          <p class="section-intro">Curious Air doesn’t blend everything into a single mysterious score. Each radio and sensor gets its own screen, its own units, and a plain note about what it can — and can’t — tell you.</p>
         </div>
         <div class="instrument-grid">
-          <article class="instrument-card"><div class="instrument-card__top"><span class="instrument-card__code">// Radio</span><span class="live">Live</span></div><h3>Networks nearby</h3><p>Inspect Wi-Fi channels, Bluetooth broadcasts, cellular cells, tracker-pattern signals, and discoverable services on your local network.</p><ul><li>Wi-Fi</li><li>BLE</li><li>Cellular</li><li>mDNS</li></ul></article>
-          <article class="instrument-card"><div class="instrument-card__top"><span class="instrument-card__code">// Position</span><span class="live">Live</span></div><h3>Sky and position</h3><p>Read GPS fixes and explore the GNSS sky by constellation, elevation, azimuth, signal strength, and reported accuracy.</p><ul><li>GPS fix</li><li>GNSS</li><li>Altitude</li><li>Bearing</li></ul></article>
-          <article class="instrument-card"><div class="instrument-card__top"><span class="instrument-card__code">// Environment</span><span class="live">Live</span></div><h3>Fields and motion</h3><p>Use the sensors your device actually has for heading, tilt, acceleration, magnetic field, light, proximity, audio, and more.</p><ul><li>Magnetic</li><li>Motion</li><li>Light</li><li>Audio</li></ul></article>
+          <article class="instrument-card">
+            <div class="instrument-card__top"><span class="instrument-card__code">01 · Radio</span><span class="tag-live">Live</span></div>
+            <h3>Networks nearby</h3>
+            <p>Watch Wi-Fi channels, Bluetooth broadcasts, and cellular cells in real time, and discover the services announcing themselves on your local network.</p>
+            <ul class="pill-row"><li>Wi-Fi</li><li>BLE</li><li>Cellular</li><li>mDNS · SSDP</li><li>Trackers</li></ul>
+          </article>
+          <article class="instrument-card instrument-card--position">
+            <div class="instrument-card__top"><span class="instrument-card__code">02 · Position</span><span class="tag-live">Live</span></div>
+            <h3>Sky and position</h3>
+            <p>Follow your GPS fix and explore the GNSS sky — every satellite your phone can hear, by constellation, elevation, azimuth, and signal strength.</p>
+            <ul class="pill-row"><li>GPS</li><li>GNSS sky map</li><li>Altitude</li><li>Bearing</li></ul>
+          </article>
+          <article class="instrument-card instrument-card--environment">
+            <div class="instrument-card__top"><span class="instrument-card__code">03 · Environment</span><span class="tag-live">Live</span></div>
+            <h3>Fields and motion</h3>
+            <p>Read the magnetic field, motion, light, proximity, pressure, and a live audio spectrum — every sensor your phone actually has.</p>
+            <ul class="pill-row"><li>Magnetic</li><li>Motion</li><li>Light</li><li>Barometer</li><li>Audio</li></ul>
+          </article>
+          <article class="instrument-card instrument-card--labs">
+            <div class="instrument-card__top"><span class="instrument-card__code">04 · Labs</span><span class="tag-labs">Experimental</span></div>
+            <h3>Inferred signals</h3>
+            <p>Try the experiments: the 60&nbsp;Hz hum of AC power read from the magnetometer, camera-based indicators, and tracker-pattern matching. Labelled experimental, because they are.</p>
+            <ul class="pill-row"><li>Field sniffer</li><li>Camera labs</li><li>Tracker patterns</li></ul>
+          </article>
         </div>
       </div>
     </section>
 
+    <!-- Showcase -->
     <section class="air-section">
       <div class="air-wrap">
         <div class="section-head">
-          <div><span class="eyebrow">The signal console</span><h2>Readings designed to be read.</h2></div>
-          <p class="section-intro">The visual language borrows from field instruments: clear labels, stable lists, live plots, and enough context to understand what a number can and cannot tell you.</p>
+          <span class="eyebrow">Field notes</span>
+          <h2>Instruments you can actually read.</h2>
+          <p class="section-intro">The design borrows from field equipment: stable lists, clear units, live plots, and enough context to know what a number means.</p>
         </div>
         <div class="showcase">
           <article class="showcase-row">
-            <div class="showcase-copy"><div class="showcase-label">Wi-Fi spectrum</div><h3>See networks by channel and strength.</h3><p>Inspect SSIDs, frequency, security, signal history, and channel placement. Filter the list when the air gets crowded.</p><ul><li>Spectrum view and live signal history</li><li>Stable scanning keeps existing results in place</li><li>On-device details without a Curious Air account</li></ul></div>
+            <div class="showcase-copy">
+              <div class="showcase-label">Wi-Fi spectrum</div>
+              <h3>The whole band, at a glance.</h3>
+              <p>Watch 2.4 and 5&nbsp;GHz as live spectrum curves. Tap a peak for its channel, width, security, and signal history — or hold the results when you want the list to sit still.</p>
+              <ul>
+                <li>Spectrum view with per-network signal history</li>
+                <li>Stable scanning — rows don’t jump while you read</li>
+                <li>Everything on-device, no account required</li>
+              </ul>
+            </div>
             <div class="showcase-art"><img class="shot shot--rear" src="../assets/screenshots/curiousair/curious-air-mainscreen-2.png" alt="Curious Air signal console home screen" width="1080" height="2124" loading="lazy" decoding="async" /><img class="shot shot--front" src="../assets/screenshots/curiousair/curious-air-wifi.png" alt="Curious Air Wi-Fi spectrum screen" width="1080" height="2124" loading="lazy" decoding="async" /></div>
           </article>
           <article class="showcase-row">
-            <div class="showcase-copy"><div class="showcase-label">Bluetooth radar</div><h3>Turn nearby broadcasts into something legible.</h3><p>Explore BLE devices by relative signal strength, inspect advertisements, decode manufacturer and service data, and connect to compatible GATT services.</p><ul><li>Radar and stable device list</li><li>Advertisement and GATT decoding free for everyone</li><li>Relative tracking with clear accuracy caveats</li></ul></div>
+            <div class="showcase-copy">
+              <div class="showcase-label">Bluetooth radar · Cellular</div>
+              <h3>Nearby devices, ranked and decoded.</h3>
+              <p>The radar places BLE devices by relative signal strength. Open one to decode its advertisements, manufacturer data, and GATT services — or switch consoles and inspect the cellular cells your phone can hear.</p>
+              <ul>
+                <li>Radar view plus a stable device list</li>
+                <li>Advertisement and GATT decoding, free for everyone</li>
+                <li>Distance is an estimate — the app says so on screen</li>
+              </ul>
+            </div>
             <div class="showcase-art"><img class="shot shot--rear" src="../assets/screenshots/curiousair/curious-air-cellular.png" alt="Curious Air cellular signal screen" width="1080" height="2124" loading="lazy" decoding="async" /><img class="shot shot--front" src="../assets/screenshots/curiousair/curious-air-bluetooth.png" alt="Curious Air Bluetooth radar screen" width="1080" height="2124" loading="lazy" decoding="async" /></div>
           </article>
           <article class="showcase-row">
-            <div class="showcase-copy"><div class="showcase-label">Sensors and environment</div><h3>Carry a pocketful of instruments.</h3><p>Read heading, pitch, roll, acceleration, magnetic field, light, proximity, relative audio level, and altitude when the hardware is available.</p><ul><li>Clean attitude and field readouts</li><li>Live audio spectrum analyzed without recording</li><li>NFC tag reading and local service discovery</li></ul></div>
+            <div class="showcase-copy">
+              <div class="showcase-label">Sensors &amp; environment</div>
+              <h3>A toolbox of small instruments.</h3>
+              <p>Heading, pitch and roll, acceleration, magnetic field, light, proximity, pressure, and a live audio spectrum — analyzed in the moment, never recorded.</p>
+              <ul>
+                <li>Clean attitude and field readouts</li>
+                <li>NFC tag reading and local service discovery</li>
+                <li>Missing hardware is shown as missing, not faked</li>
+              </ul>
+            </div>
             <div class="showcase-art"><img class="shot shot--rear" src="../assets/screenshots/curiousair/curious-air-other-sensors.png" alt="Curious Air additional sensor readings" width="1080" height="2124" loading="lazy" decoding="async" /><img class="shot shot--front" src="../assets/screenshots/curiousair/curious-air-sensors.png" alt="Curious Air sensor console" width="1080" height="2124" loading="lazy" decoding="async" /></div>
           </article>
         </div>
       </div>
     </section>
 
+    <!-- Capability -->
     <section class="air-section">
       <div class="air-wrap">
         <div class="capability">
-          <div><span class="eyebrow">Capability aware</span><h3>Every phone brings different instruments.</h3><p>Curious Air checks the hardware and Android access available on your device, then tells you what it can actually use. Unsupported sensors stay honest instead of becoming empty promises.</p><ul class="cap-pills"><li>Wi-Fi</li><li>Bluetooth</li><li>Cellular</li><li>GPS</li><li>GNSS</li><li>NFC</li><li>Magnetometer</li><li>Accelerometer</li><li>Light</li><li>Barometer</li><li>Microphone</li><li>Camera Labs</li></ul></div>
+          <div>
+            <span class="eyebrow">Capability check</span>
+            <h3>Built for the phone you actually have.</h3>
+            <p>Phones ship with different radios and sensors. Curious Air checks yours and shows the honest list — anything your device can’t do is marked unavailable, instead of quietly showing zeros.</p>
+            <ul class="pill-row"><li>Wi-Fi</li><li>Bluetooth</li><li>Cellular</li><li>GPS</li><li>GNSS</li><li>NFC</li><li>Magnetometer</li><li>Accelerometer</li><li>Light</li><li>Barometer</li><li>Microphone</li><li>Camera labs</li></ul>
+          </div>
           <figure class="cap-image"><img src="../assets/screenshots/curiousair/curious-air-capabilities.png" alt="Curious Air device capabilities screen showing available radios and sensors" width="1080" height="2124" loading="lazy" decoding="async" /></figure>
         </div>
       </div>
     </section>
 
+    <!-- Pro -->
     <section class="air-section">
       <div class="air-wrap">
         <div class="section-head">
-          <div><span class="eyebrow">Curious Air Pro</span><h2>Explore free. Pay once when you need a record.</h2></div>
-          <p class="section-intro">The app’s consoles and Bluetooth decoding remain useful without a purchase. Pro is for people who want timed observations they can take elsewhere.</p>
+          <span class="eyebrow">Curious Air Pro</span>
+          <h2>Explore free. Pay once for the record.</h2>
+          <p class="section-intro">Every live console is free — no trial timers, no locked basics. Pro exists for one job: keeping records you can take elsewhere.</p>
         </div>
         <div class="pro-block">
-          <div class="pro-copy"><span class="eyebrow">One-time unlock · No subscription</span><h3>Log signals over time. Export ordinary CSV.</h3><p>Curious Air Pro unlocks timed logging and CSV export for Wi-Fi, Bluetooth, GNSS, and cellular observations. Choose an interval and duration, save through Android’s document picker, and analyze the file in the tool you prefer.</p><div class="pro-facts"><span>Wi-Fi logs</span><span>Bluetooth logs</span><span>GNSS logs</span><span>Cellular logs</span><span>Google Play purchase</span></div></div>
+          <div class="pro-copy">
+            <span class="eyebrow">One-time purchase · No subscription</span>
+            <h3>Timed logs, exported as plain CSV.</h3>
+            <p>Choose an interval and a duration, and Curious Air logs Wi-Fi, Bluetooth, GNSS, or cellular readings while you work. Files save through Android’s own document picker and open in any spreadsheet tool.</p>
+            <div class="pill-row"><span>Wi-Fi logs</span><span>Bluetooth logs</span><span>GNSS logs</span><span>Cellular logs</span><span>One Google Play purchase</span></div>
+          </div>
           <figure class="pro-image"><img src="../assets/screenshots/curiousair/curious-air-timed-logging.png" alt="Curious Air timed logging screen with interval and duration controls" width="1080" height="2124" loading="lazy" decoding="async" /></figure>
         </div>
       </div>
     </section>
 
+    <!-- Honest limits -->
     <section class="air-section">
       <div class="air-wrap">
         <div class="section-head">
-          <div><span class="eyebrow">Clear limits, not magic claims</span><h2>A curious tool should also be an honest one.</h2></div>
-          <p class="section-intro">Signal strength moves. Phone hardware varies. Experimental indicators can be wrong. Curious Air explains those limits in the interface instead of hiding them in fine print.</p>
+          <span class="eyebrow">Honest limits</span>
+          <h2>A curious tool should be an honest one.</h2>
+          <p class="section-intro">Signal strength moves. Hardware varies. Experiments can be wrong. Curious Air says so in the interface, not in fine print.</p>
         </div>
         <div class="trust-grid">
-          <article class="trust-card"><div class="trust-label">Privacy</div><h3>Signal data is not sent to Ulix.</h3><p>Data remains on your device unless you export or share it. Local network discovery necessarily sends discovery probes on the network you are connected to, and Google Play communicates with Google to handle the optional Pro entitlement.</p></article>
-          <article class="trust-card trust-card--labs"><div class="trust-label">Labs</div><h3>Experimental means experimental.</h3><p>Camera indicators, inferred signals, tracker-pattern matches, and other Labs features are clues, not proof. They can miss real devices or flag harmless ones and should never be used for safety-critical decisions.</p></article>
+          <article class="trust-card">
+            <div class="trust-label">Privacy</div>
+            <h3>Your readings stay on your phone.</h3>
+            <p>Nothing you scan is sent to Ulix. The only network traffic the app creates: local discovery probes on the network you’re already connected to, and Google Play handling the optional Pro purchase. That’s the whole list.</p>
+          </article>
+          <article class="trust-card trust-card--labs">
+            <div class="trust-label">Labs</div>
+            <h3>Experimental means experimental.</h3>
+            <p>Camera indicators, inferred signals, and tracker-pattern matches are clues, not proof. They can miss real devices or flag harmless ones — never rely on them for safety-critical decisions.</p>
+          </article>
         </div>
       </div>
     </section>
 
+    <!-- Final CTA -->
     <section class="air-final">
-      <div class="air-wrap"><span class="eyebrow">Curiosity, instrumented</span><h2>The air around you is full of information.</h2><p>Curious Air gives you a respectful, local-first way to look.</p><a href="https://play.google.com/store/apps/details?id=com.bhunt.curiousair" target="_blank" rel="noopener" class="air-play">Join the Google Play test</a></div>
+      <div class="air-wrap">
+        <span class="eyebrow">Now testing on Google Play</span>
+        <h2>The air is full of information.</h2>
+        <p>Curious Air is a local-first, no-account way to look. Join the test and see what your phone can hear.</p>
+        <a href="https://play.google.com/store/apps/details?id=com.bhunt.curiousair" target="_blank" rel="noopener" class="air-play">Join the Google Play test</a>
+      </div>
     </section>
   </main>
 
   <footer class="site-footer">
     <div class="container">
-      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
+      <p class="footer-credo">Scan the <b>air</b> <span class="sep">·</span> Read the <b>sky</b> <span class="sep">·</span> Sense the <b>field</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand"><img src="../icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" loading="lazy" decoding="async" /></div>
         <div class="site-footer__links"><a href="../apps.html">Apps</a><a href="../blog.html">Blog</a><a href="../support.html">Support</a><a href="../about.html">About</a><a href="../contact.html">Contact</a><a href="../terms.html">Terms</a><a href="../curiousairprivacy.html">Privacy</a></div>


### PR DESCRIPTION
Fixes headings rendering near-invisible: ulix.css colors h1-h4 with
--ulix-primary, which the old landing.css redefined to the page
background, making every heading dark-on-dark. Headings now get an
explicit ink color, and the page no longer leans on that variable trick.

Also:
- Replace low-contrast text (10px labels at 43% alpha) with solid
  AA-contrast colors and a 12px monospace label style borrowed from
  the app's own console UI
- Reset .section-head, which ulix.css lays out as a space-between flex
  row, so eyebrows stack above headings
- Rewrite copy throughout: simpler hero lede, positive principle
  statements, a fourth Labs instrument card so experimental features
  are represented honestly, Bluetooth/cellular showcase copy that
  matches its screenshots, and a signal-themed footer credo replacing
  the book-themed one from the reading apps
- Style the footer credo, which previously had no styles on this page
  (its rules live in home.css, not loaded here)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EPKQk26oNGLBcp8ewEy1hv