### PR TITLE
Fix cropped Odyssey screenshot on Breaker of Horses page

### DIFF
--- a/breakerofhorses/index.html
+++ b/breakerofhorses/index.html
@@ -160,6 +160,27 @@
       width: max-content;
       margin-bottom: 18px;
     }
+
+    .boh-epic,
+    .boh-epic__copy,
+    .boh-epic__image {
+      min-width: 0;
+    }
+
+    .boh-epic__image {
+      overflow: hidden;
+    }
+
+    .boh-epic__image img {
+      object-position: top center;
+    }
+
+    @media (min-width: 1081px) {
+      .boh-epic,
+      .boh-epic__image {
+        height: 480px;
+      }
+    }
   </style>
 </head>
 


### PR DESCRIPTION
## What changed

- constrained the two epic cards to their intended 480 px desktop height instead of allowing the portrait screenshots to determine an oversized shared grid-row height
- added `min-width: 0` to the nested grid items so the screenshot columns can shrink within their cards
- keeps the screenshot crop anchored at the top and clips only within the image panel
- leaves the existing stacked tablet and mobile layouts unchanged

## Why

The taller shared desktop row caused the Odyssey screenshot to be enlarged with `object-fit: cover`, which cropped its left and right edges. Fixing the desktop panel height changes the crop to the vertical axis, so the full width of the reading screen remains visible.