### PR TITLE
Correct Breaker of Horses Homer label

### DIFF
--- a/breakerofhorses/index.html
+++ b/breakerofhorses/index.html
@@ -274,7 +274,7 @@
     <section class="boh-section boh-section--parchment">
       <div class="boh-shell">
         <div class="boh-section__head">
-          <span class="boh-eyebrow">The whole of Homer</span>
+          <span class="boh-eyebrow">Homer's epics</span>
           <div>
             <h2>Two epics. One focused reader.</h2>
             <p class="boh-section__intro">Begin with rage beneath the walls of Troy. Continue through shipwreck, temptation, recognition, and homecoming. Your place is saved separately in each work.</p>


### PR DESCRIPTION
Changes the Breaker of Horses section eyebrow from “The whole of Homer” to “Homer's epics,” accurately describing the Iliad and Odyssey without implying they constitute the entirety of works attributed to Homer.

The diff is a single copy change in `breakerofhorses/index.html`.