### PR TITLE
Add Shelf Scan iOS launch copy and privacy coverage

### DIFF
--- a/shelfscan/index.html
+++ b/shelfscan/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shelf Scan: Search Shelves Instantly</title>
-  <meta name="description" content="Shelf Scan finds books, movies, and games on your shelves by reading spines with your camera. On-device OCR, fully offline, private by design. $2.99 one-time on Google Play." />
+  <meta name="description" content="Shelf Scan finds books, movies, and games on your shelves by reading spines with your camera. On-device OCR, fully offline, private by design. $2.99 one-time on iOS and Android." />
   <link rel="canonical" href="https://ulix.app/shelfscan/" />
   <meta name="theme-color" content="#070C1A" />
 
@@ -57,7 +57,7 @@
       "url": "https://ulix.app/shelfscan/",
       "downloadUrl": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan",
       "installUrl": "https://play.google.com/store/apps/details?id=com.ulix.shelfscan",
-      "operatingSystem": "Android 7.0+",
+      "operatingSystem": "Android 7.0+; iOS 17+; iPadOS 17+",
       "applicationCategory": "UtilitiesApplication",
       "applicationSubCategory": "Visual search",
       "isAccessibleForFree": false,
@@ -95,7 +95,7 @@
         "find books on shelves",
         "offline OCR",
         "private camera search",
-        "Android utility",
+        "iOS and Android utility",
         "library inventory"
       ],
       "publisher": { "@id": "https://ulix.app/#org" },
@@ -813,7 +813,7 @@
       <section class="s-hero">
         <div class="s-hero__grid">
           <div>
-            <span class="eyebrow" style="margin-bottom:24px; display:inline-flex;">Pay once · No accounts · Works offline</span>
+            <span class="eyebrow" style="margin-bottom:24px; display:inline-flex;">$2.99 once · iOS and Android · Works offline</span>
             <h1 class="s-hero__title" style="margin-top:18px;">
               Search shelves<br>
               <em>instantly.</em>
@@ -834,6 +834,9 @@
                   <span class="play-badge__main">Google Play</span>
                 </span>
               </a>
+              <span class="ghost-btn" aria-label="Shelf Scan for iPhone and iPad, $2.99, coming soon">
+                iPhone &amp; iPad — $2.99 · Coming soon
+              </span>
               <a href="#how" class="ghost-btn">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                   <circle cx="12" cy="12" r="10"/>
@@ -1091,7 +1094,7 @@
           Organize your library<br>without <em>organizing it</em>.
         </h2>
         <p class="s-cta__body">
-          CTRL+F the World. Get Shelf Scan on Google Play for $2.99.
+          CTRL+F the World. Shelf Scan is a $2.99 one-time purchase on iOS and Android.
         </p>
         <div class="s-cta__action">
           <a href="https://play.google.com/store/apps/details?id=com.ulix.shelfscan" target="_blank" rel="noopener" class="play-badge play-badge--lg">
@@ -1106,6 +1109,9 @@
               <span class="play-badge__main">Google Play</span>
             </span>
           </a>
+          <span class="ghost-btn" aria-label="Shelf Scan for iPhone and iPad, $2.99, coming soon" style="margin-left:12px;">
+            iPhone &amp; iPad — Coming soon
+          </span>
         </div>
       </section>
 
@@ -1149,3 +1155,4 @@
   <script src="../assets/ulix.js" defer></script>
 </body>
 </html>
+

--- a/shelfscanprivacy.html
+++ b/shelfscanprivacy.html
@@ -85,9 +85,10 @@
           <li>Captured images and recognized text are saved locally on your device in the app’s private storage.</li>
           <li>No personal data is collected or transmitted. The app functions entirely offline.</li>
           <li>There are no analytics, advertising, or third-party integrations.</li>
-          <li>You may choose to export or share your saved library using Android’s standard share features. This is completely optional and controlled by you.</li>
-          <li>The app requests access to your camera (to take photos for OCR) and uses vibration (for haptic feedback when scanning).</li>
-          <li>Your data stays on your device unless you decide to share it. Android's built-in backup system may back up the local database to your Google account, depending on your device settings.</li>
+          <li>You may choose to export a Shelf Scan ZIP backup or share it through the standard Android or iOS share and file pickers. Shelf Scan does not upload backups itself.</li>
+          <li>The app requests camera access to recognize and capture shelf text and may use haptic feedback while scanning. Selecting an existing image uses the system photo picker.</li>
+          <li>Your data stays on your device unless you choose to share it. Your operating system may include app data in an encrypted device or cloud backup according to your Android, iOS, Google, or Apple backup settings.</li>
+          <li>The Android and iOS versions use separate backup formats; backups are intended for the platform that created them.</li>
         </ul>
         <p>Shelf Scan is designed to work powerfully without ever needing an internet connection.</p>
       </div>
@@ -128,3 +129,4 @@
   <script src="./assets/ulix.js" defer></script>
 </body>
 </html>
+


### PR DESCRIPTION
## What changed

- presents Shelf Scan as the same $2.99 one-time purchase on iOS and Android
- adds an accessible iPhone/iPad “Coming soon” label while the App Store URL is not yet available
- expands the privacy policy to cover iOS local storage, system photo/file/share pickers, optional device backups, and platform-specific backup formats

## Validation

Both edited pages parse with the standard HTML parser.

## Before publishing

Replace the iOS “Coming soon” labels with the final App Store URL once the App Store Connect record is live.