### PR TITLE
Clarify Curious Air landing page copy

### DIFF
--- a/curiousair/index.html
+++ b/curiousair/index.html
@@ -139,7 +139,7 @@
             </a>
             <a href="#features" class="ca-more">Learn more <svg viewBox="0 0 14 9" aria-hidden="true"><path d="M1 1l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
           </div>
-          <p class="ca-hero__note">Wi-Fi · Bluetooth · Cellular · GNSS · NFC · Sensors · Audio<br />Free to explore — now in open testing on Google Play</p>
+          <p class="ca-hero__note">Wi-Fi · Bluetooth · Cellular · GNSS · NFC · Sensors · Audio<br />Available free in open testing on Google Play.</p>
         </div>
 
         <div class="ca-hero__art" aria-hidden="true">
@@ -239,9 +239,9 @@
     <section class="ca-principles" aria-label="Product principles">
       <div class="ca-wrap ca-principles__grid">
         <div class="ca-principle"><span class="ca-principle__num">01</span><div><h3>Local-first</h3><p>Readings stay on your phone. Nothing you scan is uploaded to Ulix — data leaves your device only when you export a file yourself.</p></div></div>
-        <div class="ca-principle"><span class="ca-principle__num">02</span><div><h3>Permission-aware</h3><p>Every instrument asks first. Grant only the access you want — deny a permission and the rest of the app keeps working.</p></div></div>
-        <div class="ca-principle"><span class="ca-principle__num">03</span><div><h3>No account, no ads</h3><p>No sign-up, no profile, no feed, no cloud dashboard. Open the app and start looking.</p></div></div>
-        <div class="ca-principle"><span class="ca-principle__num">04</span><div><h3>Pay once, optional</h3><p>Everything live is free. A one-time Pro unlock adds timed logging and CSV export — no subscription.</p></div></div>
+        <div class="ca-principle"><span class="ca-principle__num">02</span><div><h3>Permission-aware</h3><p>Curious Air requests access only when a feature needs it. Denying one permission does not disable the rest of the app.</p></div></div>
+        <div class="ca-principle"><span class="ca-principle__num">03</span><div><h3>No account, no ads</h3><p>No sign-up, no profile, no feed, no cloud dashboard. Open the app and start scanning.</p></div></div>
+        <div class="ca-principle"><span class="ca-principle__num">04</span><div><h3>Optional one-time Pro upgrade</h3><p>Live views are free. Pro adds timed logging and CSV export.</p></div></div>
       </div>
     </section>
 
@@ -249,8 +249,8 @@
     <section class="ca-features" id="features">
       <div class="ca-wrap">
         <div class="ca-sechead">
-          <h2>One console per signal.</h2>
-          <p>Each radio and sensor gets its own screen, its own units, and a plain note about what it can — and can’t — tell you.</p>
+          <h2>A dedicated view for each signal and sensor.</h2>
+          <p>Each view includes the relevant units and a plain explanation of what the measurements can — and can’t — tell you.</p>
         </div>
         <div class="ca-features__grid">
           <article class="ca-card">
@@ -272,7 +272,7 @@
               <svg viewBox="0 0 34 34"><g fill="currentColor"><rect x="6" y="20" width="5" height="8" rx="1.5"/><rect x="14.5" y="14" width="5" height="14" rx="1.5"/><rect x="23" y="7" width="5" height="21" rx="1.5"/></g></svg>
             </div>
             <h3>Cellular</h3>
-            <p>Inspect the cells your phone can hear — signal strength, network type, and cell details, updated live as you move.</p>
+            <p>Inspect cellular signals detected by your phone — signal strength, network type, and cell details, updated live as you move.</p>
           </article>
           <article class="ca-card">
             <div class="ca-card__icon ca-card__icon--gnss" aria-hidden="true">
@@ -303,7 +303,7 @@
     <section class="ca-shots">
       <div class="ca-wrap">
         <div class="ca-sechead">
-          <h2>Instruments you can actually read.</h2>
+          <h2>Signal data, clearly presented.</h2>
           <p>Stable lists, clear units, live plots, and enough context to know what a number means.</p>
         </div>
         <div class="ca-showcase">
@@ -322,23 +322,23 @@
           <article class="ca-showcase__row">
             <div class="ca-showcase__copy">
               <h3>Nearby devices, ranked and decoded.</h3>
-              <p>The radar places Bluetooth devices by relative signal strength. Open one to decode its advertisements, manufacturer data, and GATT services — or switch consoles and inspect the cellular cells your phone can hear.</p>
+              <p>The radar places Bluetooth devices by relative signal strength. Open one to decode its advertisements, manufacturer data, and GATT services — or switch consoles and inspect the cellular signals detected by your phone.</p>
               <ul class="ca-checks">
                 <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Radar view plus a stable device list</li>
                 <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Advertisement and GATT decoding, free for everyone</li>
-                <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Distance is an estimate — the app says so on screen</li>
+                <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Distance estimates are clearly labelled</li>
               </ul>
             </div>
             <div class="ca-showcase__art"><img class="ca-shot ca-shot--rear" src="../assets/screenshots/curiousair/curious-air-cellular.png" alt="Curious Air cellular signal screen" width="1080" height="2124" loading="lazy" decoding="async" /><img class="ca-shot ca-shot--front" src="../assets/screenshots/curiousair/curious-air-bluetooth.png" alt="Curious Air Bluetooth radar screen" width="1080" height="2124" loading="lazy" decoding="async" /></div>
           </article>
           <article class="ca-showcase__row">
             <div class="ca-showcase__copy">
-              <h3>A toolbox of small instruments.</h3>
-              <p>Heading, pitch and roll, acceleration, magnetic field, light, proximity, pressure, and a live audio spectrum — every sensor your phone actually has, each with its own clean readout.</p>
+              <h3>Built-in sensor tools.</h3>
+              <p>Heading, pitch and roll, acceleration, magnetic field, light, proximity, pressure, and a live audio spectrum — using the sensors available on your phone, each with its own clear readout.</p>
               <ul class="ca-checks">
                 <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Clean attitude and field readouts</li>
                 <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>NFC tag reading and local service discovery</li>
-                <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Missing hardware is shown as missing, not faked</li>
+                <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Unsupported hardware is marked unavailable</li>
               </ul>
             </div>
             <div class="ca-showcase__art"><img class="ca-shot ca-shot--rear" src="../assets/screenshots/curiousair/curious-air-other-sensors.png" alt="Curious Air additional sensor readings" width="1080" height="2124" loading="lazy" decoding="async" /><img class="ca-shot ca-shot--front" src="../assets/screenshots/curiousair/curious-air-sensors.png" alt="Curious Air sensor console" width="1080" height="2124" loading="lazy" decoding="async" /></div>
@@ -352,8 +352,8 @@
       <div class="ca-wrap">
         <div class="ca-capability__panel">
           <div>
-            <h2>Built for the phone you actually have.</h2>
-            <p>Phones ship with different radios and sensors. Curious Air checks yours and shows the honest list — anything your device can’t do is marked unavailable, instead of quietly showing zeros.</p>
+            <h2>Adapts to your phone’s hardware.</h2>
+            <p>Phones ship with different radios and sensors. Curious Air detects the hardware available on your device and marks unsupported features as unavailable.</p>
             <ul class="ca-pills"><li>Wi-Fi</li><li>Bluetooth</li><li>Cellular</li><li>GPS</li><li>GNSS</li><li>NFC</li><li>Magnetometer</li><li>Accelerometer</li><li>Light</li><li>Barometer</li><li>Microphone</li></ul>
           </div>
           <figure class="ca-capability__img"><img src="../assets/screenshots/curiousair/curious-air-capabilities.png" alt="Curious Air device capabilities screen showing available radios and sensors" width="1080" height="2124" loading="lazy" decoding="async" /></figure>
@@ -373,11 +373,11 @@
               <h2>Timed Multi-Signal Logging</h2>
             </div>
             <p class="ca-pro-flag"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4 7V5a4 4 0 0 1 8 0v2m-9 0h10v7H3z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>Requires Curious Air Pro — a one-time unlock, not a subscription</p>
-            <p>Record Wi-Fi, Bluetooth, GNSS, and cellular readings together over time. Perfect for debugging, research, and field analysis.</p>
+            <p>Record Wi-Fi, Bluetooth, GNSS, and cellular readings together over time. Useful for debugging, research, and field analysis.</p>
             <ul class="ca-checks">
               <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Custom log durations and intervals</li>
               <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Export ordinary CSV through Android’s document picker</li>
-              <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Everything live stays free — Pro only unlocks the record</li>
+              <li><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#3fa857"/><path d="M6 10.5l2.6 2.6L14 7.5" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>Live views are free; Pro adds timed logging and CSV export.</li>
             </ul>
             <a href="https://play.google.com/store/apps/details?id=com.bhunt.curiousair" target="_blank" rel="noopener" class="ca-logging__cta">Get Curious Air on Google Play</a>
             <p class="ca-logging__fine">Pro is an optional one-time purchase inside the app, handled by Google Play.</p>
@@ -440,19 +440,19 @@
     <section class="ca-trust">
       <div class="ca-wrap">
         <div class="ca-sechead">
-          <h2>A curious tool should be an honest one.</h2>
-          <p>Signal strength moves. Hardware varies. Curious Air says so in the interface, not in fine print.</p>
+          <h2>Privacy and measurement limits, explained.</h2>
+          <p>Estimates, relative measurements, and unsupported hardware are labelled where they appear.</p>
         </div>
         <div class="ca-trust__grid">
           <article class="ca-trust__card">
             <span class="ca-trust__label ca-trust__label--privacy">Privacy</span>
             <h3>Your readings stay on your phone.</h3>
-            <p>Nothing you scan is sent to Ulix. The only network traffic the app creates: local discovery probes on the network you’re already connected to, and Google Play handling the optional Pro purchase. That’s the whole list.</p>
+            <p>Scan data is not sent to Ulix. Network activity is limited to local discovery probes on the network you’re already connected to and Google Play billing for the optional Pro upgrade.</p>
           </article>
           <article class="ca-trust__card">
-            <span class="ca-trust__label ca-trust__label--honesty">Honesty</span>
-            <h3>Numbers with context, not magic scores.</h3>
-            <p>Every reading comes with its units and its limits — distance estimates are labelled as estimates, audio levels are relative, and sensors your phone doesn’t have are shown as unavailable rather than faked.</p>
+            <span class="ca-trust__label ca-trust__label--honesty">Measurements</span>
+            <h3>Measurements include units and limitations.</h3>
+            <p>Every reading includes its units and limitations. Distance estimates are labelled as estimates, audio levels are relative, and unsupported sensors are marked unavailable.</p>
           </article>
         </div>
       </div>
@@ -462,7 +462,7 @@
     <section class="ca-final">
       <div class="ca-wrap">
         <h2>The air is full of information.</h2>
-        <p>Curious Air is a friendly, local-first way to look — no account, no ads. Join the test and see what your phone can hear.</p>
+        <p>Explore nearby signals and sensors without an account or ads. Available now in open testing on Google Play.</p>
         <a href="https://play.google.com/store/apps/details?id=com.bhunt.curiousair" target="_blank" rel="noopener" class="ca-gplay">
           <span class="ca-gplay__logo" aria-hidden="true">
             <svg viewBox="0 0 28 30">
@@ -480,7 +480,7 @@
 
   <footer class="site-footer">
     <div class="container">
-      <p class="footer-credo">Scan the <b>air</b> <span class="sep">·</span> Read the <b>sky</b> <span class="sep">·</span> Sense the <b>field</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
+      <p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p>
       <div class="site-footer__grid">
         <div class="site-footer__brand"><img src="../icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" loading="lazy" decoding="async" /></div>
         <div class="site-footer__links"><a href="../apps.html">Apps</a><a href="../blog.html">Blog</a><a href="../support.html">Support</a><a href="../about.html">About</a><a href="../contact.html">Contact</a><a href="../terms.html">Terms</a><a href="../curiousairprivacy.html">Privacy</a></div>


### PR DESCRIPTION
## Summary

- clarifies the Curious Air landing-page copy with more concrete, restrained language
- preserves “Explore the invisible signals around you.” in the hero and social metadata
- standardizes the footer credo to match the rest of the Ulix site

## Why

Several sections relied on anthropomorphic or moralizing language that obscured otherwise strong technical descriptions. This pass states permissions, hardware support, measurement limits, privacy, and Pro features directly while retaining the approved personality.

## Impact

Copy-only change to `curiousair/index.html`. No URLs, structured data, assets, styles, behavior, or public interfaces change.

## Validation

- confirmed the branch differs from `new` by only `curiousair/index.html`
- verified the protected hero wording is unchanged in the page title, Open Graph title, Twitter title, and visible hero
- verified links, assets, and accessibility attributes are unchanged
- verified the HTML tag sequence is unchanged
- confirmed the footer credo exactly matches `apps.html`
- confirmed the superseded visible phrases are absent