### PR TITLE
Add analytics coverage to Ulix Cortex

### DIFF
--- a/ulixcortex/index.html
+++ b/ulixcortex/index.html
@@ -325,5 +325,6 @@
       <a href="mailto:hello@ulix.app">hello@ulix.app</a>
     </div>
   </footer>
+  <script src="/assets/ulix.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the shared site script to the Ulix Cortex landing page so it uses the same Cloudflare Web Analytics implementation as the rest of the site.