### PR TITLE
Knowledge edits

### DIFF
--- a/knowledge/do-you-need-a-second-brain/index.html
+++ b/knowledge/do-you-need-a-second-brain/index.html
@@ -14,35 +14,33 @@
 <main id="main"><div class="article-shell"><p class="article-breadcrumbs"><a href="../">Ulix Knowledge</a> / Personal knowledge</p>
 <header class="article-header"><p class="article-header__meta">Personal knowledge · Keep Clip</p><h1>Do You Really Need a Second Brain?</h1><p class="article-deck">Probably not in the elaborate sense. What most people need is a reliable way to keep useful information, find it again, and turn some of it into action.</p><p class="article-byline">Donald</p></header>
 <article class="article-body">
-<p>The phrase “second brain” is attractive because it promises a solution to a real problem: human memory is selective, context disappears, and useful information arrives faster than anyone can retain it. The trouble begins when the metaphor becomes an architecture requirement. A personal knowledge system does not become better merely because it has more folders, links, dashboards, properties, templates, and review rituals.</p>
+<p>The phrase “second brain” caught on because it names a real irritation. Useful information arrives constantly, memory is selective, and the context that made a passage or idea seem important can disappear surprisingly fast.</p>
 
-<p>A smaller standard is more useful: <strong>does the system help you do something that would otherwise be harder?</strong></p>
+<p>The metaphor becomes less helpful when it suggests that the answer is to construct a miniature information institution around yourself. A personal knowledge system can have folders, backlinks, properties, dashboards, templates, review queues, and carefully maintained indexes and still fail at the ordinary moment when you need to recover something you once saved.</p>
 
-<h2>There are only a few jobs the system must do</h2>
-<p>Most personal knowledge systems can be reduced to four operations:</p>
-<ol><li><strong>Capture:</strong> keep something worth retaining.</li><li><strong>Retrieve:</strong> find it when it becomes relevant.</li><li><strong>Develop:</strong> add context, connections, notes, or decisions when those improve the material.</li><li><strong>Use:</strong> apply it to writing, learning, work, decisions, or some other real activity.</li></ol>
-<p>The fourth operation is easy to neglect. A beautifully maintained archive that rarely affects thought or action is still an archive, not an auxiliary mind.</p>
+<h2>Start with whatever is actually going wrong</h2>
+<p>Before choosing an architecture, name the failure. Perhaps useful links disappear into messages. Perhaps notes can be found but no longer make sense because the reason for saving them is gone. Perhaps reading notes never reach the writing project they were meant to support. Perhaps a large archive has become slower to search than the web.</p>
 
-<h2>Build structure after friction appears</h2>
-<p>Folders, tags, backlinks, indexes, and review queues are solutions. They should be introduced when there is a problem for them to solve. If search reliably finds a saved article, adding three tags may not improve anything. If a topic has become large enough that search returns fifty plausible results, structure may suddenly be worthwhile.</p>
+<p>Those are different problems. They do not require the same amount of structure.</p>
 
-<p>This suggests a useful principle for PKM: <strong>let complexity be earned by retrieval failure.</strong> Start simple. Add organization where the existing system produces repeated mistakes or wasted time.</p>
+<p>A small system may only need to capture material quickly and retrieve it reliably. Other material benefits from a note about why it matters, a tag that reflects a recurring project, or a connection to something already in the archive. The extra work is justified when it fixes a failure you can actually observe.</p>
 
-<h2>Do not confuse capture with learning</h2>
-<p>Saving a passage is not the same as understanding it. Highlighting is not recall. A hundred saved articles do not produce a hundred units of knowledge. When the goal is learning rather than reference, active work usually matters: solving problems, reconstructing ideas from memory, explaining a concept, comparing sources, or using the material in a project.</p>
+<h2>Storage and learning are different problems</h2>
+<p>Keeping a passage is useful when you want to quote it, check it, compare it, or return to it later. It does not by itself mean that you learned the idea in the passage. If the purpose is learning, the useful work may happen outside the archive: recalling the idea without looking, solving a problem, explaining it in your own words, or using it in a new context.</p>
 
-<p>A PKM system can support those activities. It cannot substitute for them.</p>
+<p>A knowledge system can make those activities easier by keeping the right material available. It cannot do the remembering for you.</p>
 
-<h2>Maintenance is a real cost</h2>
-<p>Every personal system has an operating budget paid in attention. Renaming notes, correcting links, reorganizing folders, maintaining templates, and reviewing inboxes can all be worthwhile. They can also consume the time the system was supposed to protect.</p>
+<h2>Maintenance should have a visible payoff</h2>
+<p>Every recurring bit of organization consumes attention. Renaming notes, correcting links, clearing an inbox, adding metadata, reorganizing folders, and running weekly reviews can all be sensible. The question is what becomes easier because that work happened.</p>
 
-<p>The relevant question is not whether a workflow is elegant. It is whether the maintenance produces enough better retrieval, learning, or decision-making to justify itself.</p>
+<p>If a weekly review reliably brings neglected projects back into view, it may be worth twenty minutes. If forty carefully chosen tags make a research archive much easier to search, keep them. If a filing ritual mainly produces a satisfying sense that the system is tidy, there is no particular reason to preserve the ritual.</p>
 
-<h2>A minimum viable personal knowledge system</h2>
-<ul><li>one dependable place to capture useful material;</li><li>search good enough to retrieve it;</li><li>optional tags or categories for recurring subjects;</li><li>portable export, so the archive is not trapped;</li><li>a habit of using the material in actual work.</li></ul>
-<p>Everything else can be added later. Some people will genuinely benefit from a sophisticated linked-note system. Others need little more than searchable clips and a writing folder. The sophistication should belong to the problem, not to the identity of being a “PKM person.”</p>
+<p>For many people, a workable setup is quite modest:</p>
+<ul><li>one fast way to capture material worth keeping;</li><li>search that can recover it later;</li><li>enough source or context to recognize why it mattered;</li><li>portable export so the archive can leave the software; and</li><li>additional organization only where repeated use has shown a need for it.</li></ul>
 
-<section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Keep Clip</h2><p><a href="../../keepclip/">Keep Clip</a> fits the lightweight end of this spectrum. It captures text and links from Android’s share menu, keeps them searchable and taggable, works offline, and exports to ordinary formats. It is not an all-purpose workspace. That is useful when the desired system is an information inbox rather than an information hobby.</p></section>
+<p>Some people genuinely need a sophisticated linked-note environment. Others will do better with searchable clips, a few project folders, and no ceremony at all. If information can be kept, recovered, and put to work when a real task calls for it, the system is already doing most of what the metaphor promised.</p>
+
+<section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Keep Clip</h2><p><a href="../../keepclip/">Keep Clip</a> fits the lightweight end of this spectrum. It captures text and links from Android’s share menu, keeps them searchable and taggable, works offline, and exports to ordinary formats. It is useful when the missing piece is a dependable information inbox rather than a general-purpose workspace.</p></section>
 </article>
 <aside class="related"><h2>Related</h2><a href="../sending-links-to-yourself/">What’s a Better System Than Sending Links to Yourself?</a></aside></div></main>
 <footer class="site-footer"><div class="container"><p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p><div class="site-footer__grid"><div class="site-footer__brand"><img src="../../icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" /></div><div class="site-footer__links"><a href="../../apps.html">Apps</a><a href="../">Knowledge</a><a href="../../about.html">About</a><a href="../../privacy.html">Privacy</a></div><div><div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div></div></div></div></footer><script src="../../assets/ulix.js" defer></script></body></html>

--- a/knowledge/keep-track-of-things-you-lend/index.html
+++ b/knowledge/keep-track-of-things-you-lend/index.html
@@ -12,29 +12,34 @@
 <body class="home-page knowledge-page"><a href="#main" class="skip-link">Skip to content</a>
 <header class="site-header"><div class="container container--wide site-header__inner"><a href="../../index.html" class="site-brand"><img src="../../icons/favicon.png" alt="" class="site-brand__logo" width="64" height="64" /><span class="site-brand__name">ULIX</span></a><nav class="site-nav" aria-label="Primary"><a href="../../index.html" class="site-nav__link">Home</a><a href="../../apps.html" class="site-nav__link">Apps</a><a href="../../blog.html" class="site-nav__link">Blog</a><a href="../../about.html" class="site-nav__link">About</a><a href="../../contact.html" class="site-nav__link">Contact</a></nav><div class="site-header__actions"><a href="../" class="btn btn--primary btn--header">Knowledge →</a></div></div></header>
 <main id="main"><div class="article-shell"><p class="article-breadcrumbs"><a href="../">Ulix Knowledge</a> / Lending</p>
-<header class="article-header"><p class="article-header__meta">Lending · Loan It</p><h1>How Do I Keep Track of Things I Lend to People?</h1><p class="article-deck">The best lending system is not a complete inventory. It is a record quick enough to make at the exact moment an object leaves your hands.</p><p class="article-byline">Annie</p></header>
+<header class="article-header"><p class="article-header__meta">Lending · Loan It</p><h1>How Do I Keep Track of Things I Lend to People?</h1><p class="article-deck">Most personal loans need only a tiny record made at handoff: what left, who has it, when it left, and any date that will help you remember it.</p><p class="article-byline">Annie</p></header>
 <article class="article-body">
-<p>Most lost loans are not caused by difficult recordkeeping. They are caused by no record at all. A book is handed across a kitchen table, a drill goes next door, a game leaves after dinner, and both people expect the transaction to remain memorable. Three months later, the item is remembered more clearly than the borrower.</p>
+<p>A surprising number of lost loans begin with complete confidence. The paperback goes home with a friend, the drill crosses the driveway, the serving dish leaves after dinner, and everybody involved knows perfectly well where it is.</p>
 
-<p>The solution does not need to resemble inventory software. For ordinary personal lending, the minimum useful record is usually just <strong>item, borrower, date out</strong>. Add a due date when timing matters and a photo when the exact object matters.</p>
+<p>For a while.</p>
 
-<h2>Record the loan at handoff</h2>
-<p>Timing matters more than sophistication. A system that takes two minutes but is always updated later is weaker than a system that takes ten seconds and is used while the borrower is still standing there.</p>
-<p>That suggests a simple design rule: the record should be possible from a phone with very little typing. A descriptive phrase such as “red Bosch drill” may be enough. A photo can replace a longer description. The borrower’s name matters more than a detailed category hierarchy.</p>
+<p>The problem is rarely that lending requires sophisticated records. It is that an ordinary object can leave in five seconds, while most recordkeeping systems require the lender to stop what is happening and become an inventory clerk.</p>
 
-<h2>Use due dates selectively</h2>
-<p>Not every loan needs a deadline. A novel lent to a friend may simply need to remain visible as outstanding. A tool needed next weekend does need a date. Adding due dates to everything creates notifications that eventually become background noise.</p>
-<p>A due date is valuable when it changes an action: ask before a trip, retrieve equipment before a project, or remind someone before the item is forgotten.</p>
+<h2>Make the record while the object is leaving</h2>
+<p>If a loan is going to be recorded, handoff is the moment. “I’ll add it later” is how a system acquires excellent fields and inaccurate data.</p>
 
-<h2>Keep returned loans long enough to be useful</h2>
-<p>There is a reason to preserve a simple history instead of deleting the record immediately. It answers questions such as “Was this already returned?” and “Who borrowed this last time?” It also prevents a returned item from remaining indefinitely on an outstanding list because somebody forgot to clean up the record.</p>
+<p>The useful entry can be extremely small. Write enough of the item name to recognize it, record the borrower, and keep the borrowed date. “Red Bosch drill” is often more useful than a perfect product description that takes too long to enter. A photo can do even more work when the exact object or its condition matters.</p>
 
-<h2>Choose a system proportional to the problem</h2>
-<p>A single note works if lending is rare. A spreadsheet is reasonable if many items are tracked and the list is usually updated from a computer. A dedicated app becomes useful when the important moment is mobile, photos matter, due dates recur, or the outstanding list needs to be checked quickly.</p>
-<p>The economic test is simple: <strong>the system should cost less attention than the forgetting it prevents.</strong> If maintaining the record is irritating enough that loans go unrecorded, the system is too heavy.</p>
+<p>A due date is optional. Sometimes there is a real deadline because the tool is needed next Saturday. Sometimes the date is mainly for the lender: a point at which the loan should come back to attention. There is no benefit in assigning artificial deadlines to every paperback and cake pan if all they produce is a stream of reminders everyone ignores.</p>
 
-<h2>A practical lending record</h2>
-<ul><li><strong>Item:</strong> enough description to distinguish it.</li><li><strong>Borrower:</strong> the person who has it.</li><li><strong>Borrowed date:</strong> useful context when memory becomes vague.</li><li><strong>Due date:</strong> only when there is a real deadline.</li><li><strong>Photo:</strong> useful for tools, electronics, books, gear, or anything visually distinctive.</li><li><strong>Returned status:</strong> the one field that keeps the outstanding list honest.</li></ul>
+<h2>Keep only the fields that answer a later question</h2>
+<p>For ordinary household lending, the questions are usually plain: What is out? Who has it? How long has it been gone? Is there a reason I need it back soon? Has it already been returned?</p>
+
+<ul><li><strong>Item:</strong> enough description to distinguish it.</li><li><strong>Borrower:</strong> the person who has it.</li><li><strong>Borrowed date:</strong> useful when “a few weeks ago” has become “sometime this spring.”</li><li><strong>Due or reminder date:</strong> when timing actually matters.</li><li><strong>Photo:</strong> useful for visually distinctive items, kits, books, tools, or gear.</li><li><strong>Returned status:</strong> what separates the outstanding list from the history.</li></ul>
+
+<p>That is usually enough. Replacement value, category, serial number, purchase date, and other inventory fields may matter for particular collections, but personal lending does not need to inherit them merely because inventory software offers them.</p>
+
+<h2>Choose the amount of system your lending actually supports</h2>
+<p>If two books leave the house in a year, a pinned note may be all the infrastructure required. A spreadsheet can make sense for a longer list, especially when it is usually maintained from a computer. A dedicated lending app earns the extra place on the phone when loans happen often enough that mobile capture, photos, reminders, borrower history, or a clean outstanding list solve recurring annoyances.</p>
+
+<p>It is also worth keeping returned records for a while instead of deleting them immediately. A short history answers “Was this already returned?” and “Who had this last?” without turning the household into an asset-management department.</p>
+
+<p>The record can stay small because the problem is small. It only has to be reliable at the moment memory stops being reliable.</p>
 
 <section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Loan It</h2><p>Loan It is an Android app for this narrow job. It records an item, borrower, borrowed and due dates, photos, and return status; it also keeps borrower history and lets outstanding loans be searched and filtered. For someone who lends one object a year, a note is simpler. For someone who routinely lends books, tools, equipment, or household items, a dedicated list can earn its place.</p><p><a href="https://play.google.com/store/apps/details?id=com.ulix.loanit">See Loan It on Google Play</a>.</p></section>
 </article>

--- a/knowledge/old-android-tablet-ereader/index.html
+++ b/knowledge/old-android-tablet-ereader/index.html
@@ -14,33 +14,31 @@
 <main id="main"><div class="article-shell"><p class="article-breadcrumbs"><a href="../">Ulix Knowledge</a> / Reading systems</p>
 <header class="article-header"><p class="article-header__meta">Reading systems · Guten</p><h1>How to Turn an Old Android Tablet Into a Dedicated E-Reader</h1><p class="article-deck">An older tablet can become a better reading device when it stops trying to be a general-purpose tablet. Give it one job, remove interruptions, and keep the library available offline.</p><p class="article-byline">Donald</p></header>
 <article class="article-body">
-<p>The most useful upgrade for an old Android tablet may be subtraction. A device that feels slow when juggling browsers, social apps, video, notifications, and modern websites can still be entirely adequate for displaying text. Reading asks relatively little of the hardware. The larger gains come from making the device quiet, predictable, and ready to open a book.</p>
+<p>An old Android tablet may be unpleasant for modern web browsing and still be perfectly adequate for books. Text does not ask much of a processor. What usually makes the device feel unsuitable for reading is everything surrounding the book: slow browser tabs, notification traffic, half a dozen signed-in services, and a home screen designed for general-purpose use.</p>
 
-<h2>1. Decide whether the tablet is still suitable</h2>
-<p>Check the screen, charging port, battery behavior, and available storage. A cracked display or battery that cannot survive a reading session defeats the point. If the device no longer receives security updates, treat it as a low-risk appliance rather than a general computing device: avoid sensitive accounts and unnecessary browsing, and keep its role narrow.</p>
+<p>Repurposing the tablet is mostly a matter of deciding what it no longer needs to do.</p>
 
-<h2>2. Remove everything that competes with reading</h2>
-<p>Uninstall or disable social apps, games, shopping apps, news alerts, and anything else that can turn an intended reading session into a tour of notifications. Turn off most notifications at the system level. Put the reader on the home screen and move utilities out of sight.</p>
+<h2>First, make sure the hardware is still worth using</h2>
+<p>A dedicated reader still needs a decent screen, a reliable charging port, enough battery for a reading session, and enough storage for the books you want on it. A weak processor is rarely the decisive problem. A swollen battery, badly damaged display, or unreliable charging port is.</p>
 
-<p>This is not a claim that distraction can be solved entirely by interface design. It is simply easier to begin reading when the device opens into a library instead of a feed.</p>
+<p>Security support matters too. If the tablet no longer receives updates, keep its job narrow. There is little reason for an obsolete reading appliance to hold sensitive accounts, email, payment information, or a browser full of authenticated sessions. Books can remain useful on hardware that you would no longer trust as your everyday computer.</p>
 
-<h2>3. Choose a reader based on the library</h2>
-<p>If the books are commercial purchases, the corresponding storefront app may be necessary. If the library is made of EPUB files, public-domain books, or documents you control, a general EPUB reader or public-domain reader can keep the setup much simpler.</p>
+<h2>Make opening a book the easiest thing the tablet can do</h2>
+<p>Remove or disable apps that regularly compete for attention, especially social feeds, games, shopping apps, and noisy news notifications. Turn off most system notifications. Put the reader where the thumb naturally lands on the home screen. Utilities can stay, but they do not need to occupy the same visual priority as the device's new purpose.</p>
 
-<p>The important capabilities are ordinary ones: reliable offline reading, readable typography, bookmarks, search, and a library view that does not require constant network access.</p>
+<p>This is a small design intervention, not a theory of human attention. A determined person can still open a browser. The advantage is simply that a reading session no longer begins with six invitations to do something else.</p>
 
-<h2>4. Download books before they are needed</h2>
-<p>A dedicated reader becomes especially useful on flights, trips, during outages, or anywhere connectivity is unreliable. Build a small offline queue rather than assuming the next book can always be fetched later. Storage demands for text-heavy EPUB books are modest compared with video or photographs, so even an older device can hold a substantial library.</p>
+<p>Once the tablet is quiet, set up the reader around the books you actually have. Commercial purchases may require the corresponding storefront app. EPUB files and public-domain books give you more freedom to choose a reader for typography, search, bookmarks, notes, and reliable offline access rather than for the store attached to it.</p>
 
-<h2>5. Adjust the physical reading experience</h2>
-<ul><li>Set text size for comfortable sustained reading rather than maximum words per page.</li><li>Use warm or dark themes when they are easier on the eyes in the relevant environment.</li><li>Reduce screen timeout if accidental sleep is annoying, but not so far that the display stays on indefinitely.</li><li>Use airplane mode when the library is already downloaded and connectivity is unnecessary.</li><li>Consider a simple stand for a larger tablet used at a desk or bedside.</li></ul>
+<h2>Give it a real offline shelf</h2>
+<p>A dedicated reader is more useful when the next book is already there. Download several books before a trip, an outage, or a long afternoon away from Wi-Fi. Text-heavy EPUB files are small enough that an older tablet can usually hold far more books than anyone needs in an immediate queue.</p>
 
-<h2>6. Keep the device boring</h2>
-<p>The dedicated-reader idea works because the tablet acquires a clear default behavior. If every old app remains installed and every account remains signed in, it is still a tablet that happens to contain books. If the home screen contains little besides reading, the object begins to behave more like a tool.</p>
+<p>Then adjust the physical reading experience rather than accepting the device's old settings by default:</p>
+<ul><li>use a text size that remains comfortable after an hour, not one chosen to maximize words per page;</li><li>choose a light, warm, or dark theme according to the room and your eyes;</li><li>set screen timeout so it is not constantly interrupting a slow page;</li><li>use airplane mode when the books are downloaded and connectivity adds nothing; and</li><li>consider a simple stand if a larger tablet will mostly live beside a chair, bed, or desk.</li></ul>
 
-<p>That distinction is useful beyond reading. Old hardware often becomes more valuable when its purpose becomes narrower.</p>
+<p>The resulting device does not need to imitate a new dedicated e-reader in every respect. If it wakes reliably, opens the current book, works without a network, and stays out of the way while you read, an otherwise obsolete tablet can still have a very good job.</p>
 
-<section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Guten</h2><p><a href="../../guten/">Guten</a> is a free Android reader for the Project Gutenberg catalog. It can search and import public-domain books, keep them available offline, and supports bookmarks, highlights, notes, text search, and export. On an old Android tablet, that makes it one way to create a large classics library without tying the device to a purchasing ecosystem.</p></section>
+<section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Guten</h2><p><a href="../../guten/">Guten</a> is a free Android reader for the Project Gutenberg catalog. It can search and import public-domain books, keep them available offline, and supports bookmarks, highlights, notes, text search, and export. On an old Android tablet, it is one way to create a large classics library without making a commercial bookstore the center of the device.</p></section>
 </article>
 <aside class="related"><h2>Related</h2><a href="../read-classic-books-free/">Where Can I Read Classic Books for Free?</a><a href="../read-classics-without-kindle/">How Can I Read Classic Literature Without Amazon or Kindle?</a></aside></div></main>
 <footer class="site-footer"><div class="container"><p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p><div class="site-footer__grid"><div class="site-footer__brand"><img src="../../icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" /></div><div class="site-footer__links"><a href="../../apps.html">Apps</a><a href="../">Knowledge</a><a href="../../about.html">About</a><a href="../../privacy.html">Privacy</a></div><div><div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div></div></div></div></footer><script src="../../assets/ulix.js" defer></script></body></html>

--- a/knowledge/paper-list-spreadsheet-or-app-lending/index.html
+++ b/knowledge/paper-list-spreadsheet-or-app-lending/index.html
@@ -14,31 +14,35 @@
 <main id="main"><div class="article-shell"><p class="article-breadcrumbs"><a href="../">Ulix Knowledge</a> / Comparison</p>
 <header class="article-header"><p class="article-header__meta">Comparison · Loan It</p><h1>Paper List, Spreadsheet, or App: What’s Best for Tracking Things You’ve Lent?</h1><p class="article-deck">Use the least complicated system that will actually be updated when an item leaves. Features matter only when they prevent a failure you really have.</p><p class="article-byline">Annie</p></header>
 <article class="article-body">
-<p>There is no general reason to buy or install dedicated software for a problem that a sheet of paper solves perfectly. Lending is a good example. The right system depends on volume, frequency, and the cost of forgetting. A person who lends two books a year has a different problem from someone whose tools, games, books, and equipment circulate constantly among friends and family.</p>
+<p>If you lend two books a year, a pinned note or a sheet of paper may be all the lending software you need. If books, tools, games, and equipment are constantly moving among several people, paying a little more attention to the record can save a surprising amount of hunting later.</p>
+
+<p>The useful comparison is therefore less about feature count than about where the record is made and how much friction the method introduces at handoff.</p>
 
 <div class="compare-table-wrap"><table class="compare-table"><thead><tr><th>Method</th><th>Best at</th><th>Main weakness</th></tr></thead><tbody><tr><td>Paper list</td><td>Zero setup; visible household record</td><td>Not searchable or available away from home</td></tr><tr><td>Single note</td><td>Fast phone capture</td><td>Gets messy as loans accumulate</td></tr><tr><td>Spreadsheet</td><td>Flexible columns, sorting, long lists</td><td>Mobile capture can feel clerical</td></tr><tr><td>Dedicated app</td><td>Fast handoff, photos, dates, status, reminders</td><td>Another app to maintain</td></tr></tbody></table></div>
 
-<h2>Paper is better than it gets credit for</h2>
-<p>A notebook beside the place where items usually leave the house can be excellent. It has no account, no battery, no subscription, and almost no learning curve. If everyone in the household sees it and lending happens at home, paper may be the cheapest adequate solution.</p>
-<p>Its weakness is location. The list cannot answer a question while away from home, cannot search a long history, and cannot remind anyone that something is due.</p>
+<h2>Start at the cheap end</h2>
+<p>Paper is better than it gets credit for. A notebook beside the cabinet, tool bench, or shelf where lending usually happens has no account, battery, subscription, or learning curve. In a household where the record only needs to be checked at home, those are substantial advantages.</p>
 
-<h2>A single phone note is the true minimum</h2>
-<p>For occasional lending, a pinned note titled “Lent Out” is difficult to beat. Add one line per loan: item, borrower, date. Delete or mark the line when the item returns.</p>
-<p>The system begins to fail when the note becomes long enough that overdue items, borrower history, and returned loans are mixed together. That may never happen. If it does not, keep the note.</p>
+<p>A pinned phone note solves paper's location problem with almost no additional complexity. “Cordless drill, Sam, Aug. 4” is a perfectly respectable lending record. If the list remains short enough to scan, there is no prize for replacing it.</p>
 
-<h2>Spreadsheets are good when the list is the product</h2>
-<p>A spreadsheet is powerful because it is explicit. Columns can be added for borrower, date, category, replacement value, location, or anything else. Sorting and filtering are easy. Export is inherent.</p>
-<p>The tradeoff is capture friction. Lending often happens in a doorway, garage, classroom, church hall, or driveway. If recording the transaction feels like data entry, updates are postponed. Once that happens, the spreadsheet’s theoretical completeness has little value.</p>
+<p>Both methods begin to strain when the question changes from “Who has this?” to “What is currently outstanding, what is overdue, and what has this person borrowed before?” That is the point at which more structure can earn its keep.</p>
 
-<h2>A dedicated app earns its place through handoff speed</h2>
-<p>The strongest case for a lending app is not that it stores more fields. It is that the interface can be designed around the moment of lending: identify the object, identify the person, add a date or photo if useful, save, done.</p>
-<p>Reminders, borrower histories, photos, and filters are valuable only for people who use them. The extra structure is justified when it reduces the chance that an outstanding item disappears from attention.</p>
+<h2>Spreadsheets are good when you actually want a structured list</h2>
+<p>A spreadsheet is flexible and cheap. Borrower, date, category, replacement value, location, notes, and whatever else matters can become columns. Sorting and filtering are familiar, and the data is easy to move elsewhere.</p>
 
-<h2>A simple decision rule</h2>
-<ul><li><strong>Use paper</strong> if the record stays in one place and lending is infrequent.</li><li><strong>Use a note</strong> if the list is short and the phone is always at hand.</li><li><strong>Use a spreadsheet</strong> if flexible analysis and a larger structured list matter.</li><li><strong>Use a dedicated app</strong> if mobile capture, reminders, photos, borrower history, or an always-current outstanding list are worth the extra tool.</li></ul>
-<p>The best system is not the one with the highest ceiling. It is the one that keeps the record accurate at the lowest recurring cost.</p>
+<p>Its practical weakness is the doorway problem. Lending often happens while somebody is leaving with the object. Opening a sheet, finding the right row, and entering several fields can feel absurdly clerical for a cake pan or a board game. If the spreadsheet is consistently updated later, its flexibility is not doing much for you.</p>
 
-<section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Loan It</h2><p>Loan It is the dedicated-app option in this comparison. It records item descriptions, borrowers, dates, photos, and return status, with search, filters, sorting, reminders, and borrower history. That is more machinery than a short note needs and less than a general inventory system. The intended use is the middle: people who lend enough things that forgetting has become predictable.</p><p><a href="https://play.google.com/store/apps/details?id=com.ulix.loanit">See Loan It on Google Play</a>.</p></section>
+<h2>A dedicated app has to justify being another app</h2>
+<p>The strongest case is speed at the exact moment of lending. An interface built for the transaction can record the object, borrower, date, and perhaps a photo before the borrower leaves. Reminders, borrower histories, filters, and return status become useful after there are enough loans for a flat list to require work.</p>
+
+<p>That still does not mean every lender needs one. The extra structure is worth having when it prevents a recurring failure: forgotten loans, missing kit pieces, uncertainty about what is still out, or the need to reconstruct months of lending from memory.</p>
+
+<p>A quick rule is enough for most households:</p>
+<ul><li><strong>Paper or a phone note:</strong> occasional lending and a short list.</li><li><strong>Spreadsheet:</strong> a larger structured record that is comfortably maintained as data.</li><li><strong>Dedicated app:</strong> frequent mobile handoffs where photos, reminders, borrower history, or a current outstanding list save real effort.</li></ul>
+
+<p>If the simple method stays accurate, keep it. Move up only when you can name the problem the extra machinery will solve.</p>
+
+<section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Loan It</h2><p>Loan It is the dedicated-app option in this comparison. It records item descriptions, borrowers, dates, photos, and return status, with search, filters, sorting, reminders, and borrower history. That is more machinery than a short note needs and less than a general inventory system. It fits the middle case: people who lend enough things that forgetting has become predictable.</p><p><a href="https://play.google.com/store/apps/details?id=com.ulix.loanit">See Loan It on Google Play</a>.</p></section>
 </article>
 <aside class="related"><h2>Related</h2><a href="../keep-track-of-things-you-lend/">How Do I Keep Track of Things I Lend to People?</a></aside></div></main>
 <footer class="site-footer"><div class="container"><p class="footer-credo">Find the <b>book</b> <span class="sep">·</span> Save the <b>passage</b> <span class="sep">·</span> Read the <b>classic</b> <span class="sep">·</span> Keep the <b>record</b> <span class="sep">·</span> Own the <b>data</b></p><div class="site-footer__grid"><div class="site-footer__brand"><img src="../../icons/ulixwordmarkclear.png" alt="Ulix — Precision tools for modern odysseys" class="footer-wordmark" width="1754" height="717" /></div><div class="site-footer__links"><a href="../../apps.html">Apps</a><a href="../">Knowledge</a><a href="../../about.html">About</a><a href="../../privacy.html">Privacy</a></div><div><div class="site-footer__copyright">© 2026 Ulix LLC. All rights reserved.</div></div></div></div></footer><script src="../../assets/ulix.js" defer></script></body></html>

--- a/knowledge/read-classics-without-kindle/index.html
+++ b/knowledge/read-classics-without-kindle/index.html
@@ -14,32 +14,29 @@
 <main id="main"><div class="article-shell"><p class="article-breadcrumbs"><a href="../">Ulix Knowledge</a> / Reading</p>
 <header class="article-header"><p class="article-header__meta">Reading · Guten</p><h1>How Can I Read Classic Literature Without Amazon or Kindle?</h1><p class="article-deck">Kindle is one very successful way to buy and read ebooks. It is not the definition of an ebook library, and classic literature is unusually easy to read outside a commercial storefront.</p><p class="article-byline">Nico</p></header>
 <article class="article-body">
-<p>The modern ebook can appear inseparable from the store that sold it because commercial readers are designed to make acquisition and reading feel like one continuous system. Historically, those are different functions. A text can come from a publisher, library, archive, public-domain repository, or personal collection; a reading application is simply the instrument used to display and navigate it.</p>
+<p>Kindle is very good at making several separate things feel like one thing. The store, your account, the library, the book file, and the reading software appear as a single continuous experience. That convenience is real. It can also make the commercial system look more fundamental than it is.</p>
 
-<p>For classic literature, that separation is particularly useful. Many older works are available as ordinary EPUB files from public-domain collections, so a reader can assemble a substantial library without depending on a single bookstore account.</p>
+<p>A book can come from a publisher, a library, an archive, a public-domain repository, or a file you already own. The application that displays it is another layer. For readers of classics, separating those layers is unusually practical because so many texts can be obtained as ordinary ebook files.</p>
 
-<h2>Begin with open ebook files</h2>
-<p>EPUB is a common ebook format supported by many reading applications and devices. Public-domain repositories such as <a href="https://www.gutenberg.org/">Project Gutenberg</a> distribute books in downloadable formats rather than requiring them to remain inside one proprietary library interface.</p>
+<h2>Build the library from books and editions</h2>
+<p><a href="https://www.gutenberg.org/">Project Gutenberg</a> distributes public-domain books in downloadable formats including EPUB. A file you download can be stored, backed up, moved to another compatible reader, and kept offline. Changing reading software does not necessarily mean changing the library.</p>
 
-<p>This changes the relationship to the book in a small but important way. The file can be stored, backed up, moved between compatible readers, and kept available offline. The reader software can change without necessarily requiring the library to be repurchased.</p>
+<p>That freedom does not make every free edition equally desirable. Homer may be in the public domain, while a recent translation, scholarly introduction, or annotated edition remains copyrighted. An old translation may be exactly what you want, or it may be the reason a classic feels unnecessarily remote. Public libraries are especially useful here because they let a reader borrow modern editions without turning every comparison into a purchase.</p>
 
-<h2>Use libraries for books that are not in the public domain</h2>
-<p>Not every useful edition of a classic is free. Modern translations, scholarly editions, introductions, and annotations can remain copyrighted even when the underlying ancient or older work is public domain. Public libraries are often the best complement to a public-domain collection because they provide access to newer editions without requiring every comparison to become a purchase.</p>
+<p><a href="https://standardebooks.org/">Standard Ebooks</a> is another useful source when it has the title you want. Its catalog is much smaller than Project Gutenberg's, but the books are deliberately prepared as modern ebooks. The difference is a reminder that “the text” and “the edition” are related without being identical.</p>
 
-<h2>Choose a reader after choosing the library</h2>
-<p>A person whose collection consists mostly of purchased Kindle books has a strong reason to use Kindle software. A person building a library from EPUBs has different priorities: file import, offline availability, typography, bookmarks, notes, search, and perhaps export of annotations.</p>
+<h2>Choose the reader after you know what the library contains</h2>
+<p>Someone with hundreds of Kindle purchases has an obvious reason to keep using Kindle software. Someone assembling a collection from EPUB files has a different set of questions. Does the reader import files easily? Does it work well offline? Are the typography and search good? Can bookmarks or annotations be kept or exported in a useful form?</p>
 
-<p>There is no particular virtue in avoiding a large platform merely for the sake of avoidance. The useful question is whether the platform solves a problem you have or imposes a dependency you do not need.</p>
+<p>Avoiding a large platform is not an accomplishment by itself. The advantage is having a choice when the commercial ecosystem is not doing anything you need.</p>
 
-<h2>Public-domain books make experimentation cheap</h2>
-<p>Classic literature is a good place to compare reading systems because the texts themselves are often freely available. The same novel can be loaded into several readers. Different editions can be compared. An old Android tablet can become a dedicated library without an expensive initial book purchase.</p>
+<p>An independent classics setup can be quite ordinary:</p>
+<ul><li>download the public-domain books you want to keep from a reputable source;</li><li>borrow modern copyrighted translations or editions when they are better suited to the reading;</li><li>keep a backup of files you care about; and</li><li>use any compatible reader that makes those books pleasant to read.</li></ul>
 
-<p>It also becomes easier to encounter books outside the narrow shelf of whatever is currently being promoted. Project Gutenberg contains famous works, but also memoirs, forgotten novels, old histories, sermons, travel narratives, scientific writing, translations, and oddities that commercial stores have little reason to surface.</p>
+<h2>The public domain is larger than the familiar shelf</h2>
+<p>Once the storefront stops determining what is visible, the collection becomes stranger and more interesting. Project Gutenberg has the obvious Austen, Dickens, Melville, and Shakespeare, but it also has old histories, memoirs, sermons, travel accounts, forgotten novels, translations, scientific works, and books that no commercial store has much incentive to place in front of you.</p>
 
-<h2>A simple independent setup</h2>
-<ol><li>Choose a source for the books, such as Project Gutenberg or Standard Ebooks.</li><li>Download EPUB files for books worth keeping.</li><li>Store a backup somewhere you control.</li><li>Use an Android, iOS, desktop, or dedicated reading application that accepts the files.</li><li>Keep the books downloaded if offline access matters.</li><li>Use a public library when a modern copyrighted edition is preferable.</li></ol>
-
-<p>This is not a rejection of Kindle. It is a reminder that a library can be constructed around books first and storefronts second.</p>
+<p>That is one of the pleasures of an independent classics library. The text has often outlived several generations of booksellers, formats, and reading machines already. There is no particular reason the current storefront has to become part of the book's identity.</p>
 
 <section class="product-note"><p class="product-note__label">A relevant Ulix tool</p><h2>Guten</h2><p><a href="../../guten/">Guten</a> is a free Android reader centered on Project Gutenberg. It searches the public-domain catalog, imports books for offline reading, and supports highlights, notes, bookmarks, text search, and export. For a reader primarily interested in classics, it is one way to make the public-domain library the center of the experience rather than a commercial store.</p></section>
 </article>


### PR DESCRIPTION
Refines five evergreen Ulix Knowledge guides for tighter prose, less repetitive section structure, and clearer author-specific voice. Preserves the existing URLs, factual claims, product positioning, and discovery files.