### PR TITLE
Improve Knowledge article header spacing

### DIFF
--- a/knowledge/knowledge.css
+++ b/knowledge/knowledge.css
@@ -90,17 +90,17 @@
 .editor strong { display: block; font: 600 13px/1.2 var(--k-sans); color: var(--k-ink); }
 .editor span { display: block; margin-top: 7px; font: 400 12px/1.45 var(--k-sans); color: var(--k-subtle); }
 
-.article-shell { width: min(920px, calc(100% - 40px)); margin: 0 auto; padding: 68px 0 110px; }
-.article-breadcrumbs { margin: 0 0 42px; font: 500 12px/1.4 var(--k-sans); color: var(--k-subtle); }
+.article-shell { width: min(920px, calc(100% - 40px)); margin: 0 auto; padding: 82px 0 110px; }
+.article-breadcrumbs { margin: 0 0 34px; font: 500 11px/1.4 var(--k-sans); letter-spacing: .035em; color: var(--k-subtle); }
 .article-breadcrumbs a { text-decoration: none; }
 .article-breadcrumbs a:hover { color: var(--k-ink); }
-.article-header { max-width: 850px; padding-bottom: 40px; border-bottom: 1px solid var(--k-rule); }
-.article-header__meta { margin-bottom: 18px; font: 600 11px/1.35 var(--k-sans); letter-spacing: .13em; text-transform: uppercase; color: var(--k-gold); }
-.article-header h1 { font-size: clamp(43px, 6vw, 70px); line-height: .98; }
-.article-deck { max-width: 760px; margin: 24px 0 0; font: 400 19px/1.55 var(--k-sans); color: var(--k-muted); }
-.article-byline { margin: 23px 0 0; font: 500 12px/1.4 var(--k-sans); color: var(--k-subtle); }
+.article-header { max-width: 860px; padding-bottom: 54px; border-bottom: 1px solid var(--k-rule); }
+.article-header__meta { margin: 0 0 24px; font: 600 10px/1.35 var(--k-sans); letter-spacing: .15em; text-transform: uppercase; color: var(--k-gold); }
+.article-header h1 { max-width: 820px; font-size: clamp(43px, 6vw, 70px); line-height: 1.035; }
+.article-deck { max-width: 760px; margin: 30px 0 0; font: 400 19px/1.58 var(--k-sans); color: var(--k-muted); }
+.article-byline { margin: 28px 0 0; font: 500 12px/1.4 var(--k-sans); color: var(--k-subtle); }
 
-.article-body { max-width: 740px; margin: 48px auto 0; font: 400 18px/1.72 var(--k-serif); color: rgba(244,239,230,.9); }
+.article-body { max-width: 740px; margin: 64px auto 0; font: 400 18px/1.72 var(--k-serif); color: rgba(244,239,230,.9); }
 .article-body > p:first-child { font-size: 22px; line-height: 1.58; color: var(--k-ink); }
 .article-body h2 { margin: 50px 0 17px; font: 400 34px/1.08 var(--k-serif); letter-spacing: -.02em; color: var(--k-ink); }
 .article-body h3 { margin: 34px 0 12px; font: 600 16px/1.25 var(--k-sans); color: var(--k-ink); }
@@ -138,7 +138,13 @@
   .knowledge-grid, .guide-index-grid { grid-template-columns: 1fr; }
   .knowledge-card { min-height: 0; }
   .editor-list { grid-template-columns: repeat(2, minmax(0,1fr)); }
-  .article-body { font-size: 17px; }
+  .article-breadcrumbs { margin-bottom: 28px; }
+  .article-header { padding-bottom: 42px; }
+  .article-header__meta { margin-bottom: 18px; }
+  .article-header h1 { font-size: clamp(40px, 11vw, 56px); line-height: 1; }
+  .article-deck { margin-top: 22px; font-size: 18px; line-height: 1.52; }
+  .article-byline { margin-top: 20px; }
+  .article-body { margin-top: 46px; font-size: 17px; }
   .knowledge-search { flex-direction: column; }
   .knowledge-search button { min-height: 44px; }
 }


### PR DESCRIPTION
Refines the shared Knowledge article header styling.

- Adds more separation between breadcrumbs, subject metadata, title, deck, byline, divider, and article body.
- Slightly relaxes title line-height and constrains title width for cleaner wrapping.
- Reduces the visual repetition between breadcrumb metadata and the subject/app eyebrow.
- Adds responsive spacing adjustments so mobile headers remain compact without feeling crowded.

This is a shared CSS-only change; article content and URLs are unchanged.